### PR TITLE
Increase cache TTL to 24h and add warm-up job

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ The app is highly configurable through environment variables:
 - `GET /api/news` - Fetch all news articles
 - `GET /api/summarize` - Generate AI summary for articles
 - `GET /api/clear-cache` - Clear application cache
+- `GET /api/warmup` - Background job endpoint to keep caches warm
 - `GET /api/resolve-image` - Resolve and normalize image URLs
 
 ## 📈 Performance

--- a/src/app/api/news/route.ts
+++ b/src/app/api/news/route.ts
@@ -15,7 +15,7 @@ export async function GET(request: Request) {
   let articles: Article[] = await getCachedData(cacheKey)
   if (!articles) {
     articles = await fetchAllNews()
-    await setCachedData(cacheKey, articles, 300) // 5 min cache
+    await setCachedData(cacheKey, articles, 60 * 60 * 24) // 24h cache
   }
 
   // Filter and paginate

--- a/src/app/api/warmup/route.ts
+++ b/src/app/api/warmup/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server'
+import { fetchAllNews } from '@/lib/newsService'
+
+export async function GET() {
+  try {
+    await fetchAllNews()
+    return NextResponse.json({ status: 'warmed' })
+  } catch (error) {
+    console.error('Warmup failed', error)
+    return NextResponse.json({ status: 'error' }, { status: 500 })
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,8 @@ import { filterByTopic, getParamString } from '@/lib/utils'
 
 export const revalidate = 1800 // 30 minutes instead of 10 to reduce server load
 
+const DAY_IN_SECONDS = 60 * 60 * 24
+
 // Composed homepage renderer
 function renderHomepage(
   storyClusters: StoryCluster[],
@@ -109,14 +111,14 @@ export default async function Home({
 
     if (rateLimitMessage) {
       console.log(`⚠️ ${rateLimitMessage}`)
-      // Cache rate limit result for only 2 minutes to allow faster retries
-      await setCachedData('homepage-result', homepageResult, 120) // 2 min cache for rate limit scenarios
+      // Cache rate limit result for a full day to avoid recomputation
+      await setCachedData('homepage-result', homepageResult, DAY_IN_SECONDS) // 24h cache
     } else {
       console.log(
         `✅ Processed ${storyClusters.length} story clusters and ${unclusteredArticles.length} individual articles`
       )
-      // Cache successful result for longer
-      await setCachedData('homepage-result', homepageResult, 600) // 10 min cache for successful results
+      // Cache successful result for a day
+      await setCachedData('homepage-result', homepageResult, DAY_IN_SECONDS) // 24h cache for successful results
     }
     return renderHomepage(storyClusters, unclusteredArticles, rateLimitMessage, topics)
   } catch (error) {

--- a/src/lib/newsService.ts
+++ b/src/lib/newsService.ts
@@ -567,9 +567,9 @@ export async function fetchAllNews(): Promise<Article[]> {
 
   log('info', `✅ Final articles: ${articlesWithPlaceholders.length}`)
 
-  // Cache the results for 15 minutes to reduce server load
+  // Cache the results for 24 hours to reduce server load and avoid cold starts
   if (articlesWithPlaceholders.length > 0) {
-    await setCachedData('all-news', articlesWithPlaceholders, 900) // 15 minutes
+    await setCachedData('all-news', articlesWithPlaceholders, 60 * 60 * 24) // 24 hours
     log('info', `💾 Cached ${articlesWithPlaceholders.length} articles`)
   }
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/warmup",
+      "schedule": "*/5 * * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Extend cache lifetimes to one day for homepage and news feed
- Add scheduled warmup endpoint with valid Vercel `crons` configuration
- Document warmup API endpoint

## Testing
- `pnpm lint` *(fails: prompts for ESLint configuration)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c631d6f8d883249c75dae06abcc595