### PR TITLE
Refactor HomeClient and CategorySummary components to conditionally render summary

### DIFF
--- a/src/components/HomePage/HomeClient.tsx
+++ b/src/components/HomePage/HomeClient.tsx
@@ -153,13 +153,14 @@ export default function HomeClient({ initialData }: HomeClientProps) {
           closeSummary={handleCloseSummary}
         />
 
-        <CategorySummary
-          topic={topic || undefined}
-          clusters={filtered.clusters}
-          unclustered={filtered.unclustered}
-          isSummaryOpen={isSummaryOpen}
-          onClose={handleCloseSummary}
-        />
+        {isSummaryOpen && (
+          <CategorySummary
+            topic={topic || undefined}
+            clusters={filtered.clusters}
+            unclustered={filtered.unclustered}
+            onClose={handleCloseSummary}
+          />
+        )}
 
         <NewsList storyClusters={filtered.clusters} unclusteredArticles={filtered.unclustered} />
 

--- a/src/components/Summary/CategorySummary.tsx
+++ b/src/components/Summary/CategorySummary.tsx
@@ -10,7 +10,6 @@ interface CategorySummaryProps {
   topic?: string
   clusters: StoryCluster[]
   unclustered: Article[]
-  isSummaryOpen: boolean
   onClose: () => void
 }
 
@@ -18,13 +17,7 @@ export interface CategorySummaryRef {
   requestSummary: () => void
 }
 
-export function CategorySummary({
-  topic,
-  clusters,
-  unclustered,
-  isSummaryOpen,
-  onClose,
-}: CategorySummaryProps) {
+export function CategorySummary({ topic, clusters, unclustered, onClose }: CategorySummaryProps) {
   const isTrending = !topic
   const summaryTitle = isTrending ? 'Summary of the Day' : `${topic} Highlights`
   const buttonLabel = isTrending ? "Summarize today's news" : `Summarize ${topic}`
@@ -65,7 +58,6 @@ export function CategorySummary({
     articleId: payload?.id || `category-${slug}-${simpleHash(slugSource)}`,
     content: payload?.content || '',
     eager: false,
-    disabled: !isSummaryOpen,
     variant: 'article',
     mode,
     purpose: 'category',
@@ -79,15 +71,13 @@ export function CategorySummary({
   const articleCountLabel = `${payload.articleCount} article${payload.articleCount === 1 ? '' : 's'} analyzed`
 
   useEffect(() => {
-    if (isSummaryOpen) requestSummary()
-  }, [isSummaryOpen, requestSummary])
+    requestSummary()
+  }, [requestSummary])
 
   const hasSummary = Boolean(summary)
   const containerClass = !hasSummary
     ? 'flex justify-end'
-    : !isSummaryOpen
-      ? 'flex justify-end'
-      : 'rounded-2xl border border-border bg-card/60 backdrop-blur p-6 sm:p-7 shadow-sm'
+    : 'rounded-2xl border border-border bg-card/60 backdrop-blur p-6 sm:p-7 shadow-sm'
 
   const errorContent = (
     <div className="inline-flex items-center gap-2">
@@ -118,35 +108,33 @@ export function CategorySummary({
         loadingContent={<LoadingSpinner variant="cluster" articleCount={payload.articleCount} />}
         errorContent={errorContent}
       >
-        {summary
-          ? isSummaryOpen && (
-              <div className="space-y-4">
-                <div className="flex flex-wrap items-center justify-between gap-3">
-                  <div className="flex items-center gap-3">
-                    <Badge variant="secondary">{summaryTitle}</Badge>
-                    <span className="text-xs text-muted-foreground">{articleCountLabel}</span>
-                  </div>
-                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                    <span className="hidden sm:inline">AI-powered digest</span>
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      onClick={onClose}
-                      className="h-7 px-2 text-xs text-muted-foreground hover:text-foreground cursor-pointer"
-                    >
-                      Hide summary
-                    </Button>
-                  </div>
-                </div>
-                <AISummaryTitle />
-                <p className="text-base leading-relaxed text-foreground/90">{summary}</p>
-                <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                  <span className="inline-flex h-1.5 w-1.5 rounded-full bg-accent animate-pulse" />
-                  <span>{articleCountLabel}</span>
-                </div>
+        {summary && (
+          <div className="space-y-4">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div className="flex items-center gap-3">
+                <Badge variant="secondary">{summaryTitle}</Badge>
+                <span className="text-xs text-muted-foreground">{articleCountLabel}</span>
               </div>
-            )
-          : null}
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <span className="hidden sm:inline">AI-powered digest</span>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={onClose}
+                  className="h-7 px-2 text-xs text-muted-foreground hover:text-foreground cursor-pointer"
+                >
+                  Hide summary
+                </Button>
+              </div>
+            </div>
+            <AISummaryTitle />
+            <p className="text-base leading-relaxed text-foreground/90">{summary}</p>
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <span className="inline-flex h-1.5 w-1.5 rounded-full bg-accent animate-pulse" />
+              <span>{articleCountLabel}</span>
+            </div>
+          </div>
+        )}
       </SummaryBase>
     </section>
   )


### PR DESCRIPTION
- Updated HomeClient to render CategorySummary only when isSummaryOpen is true, improving performance and user experience.
- Removed isSummaryOpen prop from CategorySummary, simplifying its interface and logic.
- Adjusted useEffect in CategorySummary to always request summary on mount, ensuring consistent behavior.