### PR TITLE
Enhance RSS feed content handling in newsService

### DIFF
--- a/src/lib/news/newsService.ts
+++ b/src/lib/news/newsService.ts
@@ -25,6 +25,8 @@ const parser = new Parser({
   },
   customFields: {
     item: [
+      // Prefer full content when feeds provide it
+      ['content:encoded', 'content:encoded'],
       ['media:content', 'media:content'],
       ['media:thumbnail', 'media:thumbnail'],
       ['media:group', 'media:group'],
@@ -375,7 +377,9 @@ export async function fetchRSSFeed(url: string, category: string): Promise<Artic
             }
           }
           if (!dims.width && !dims.height) {
-            const fromContent = extractImageFromContentWithDims(item.content || item.contentSnippet)
+            const fromContent = extractImageFromContentWithDims(
+              (item as any)['content:encoded'] || item.content || item.contentSnippet
+            )
             if (fromContent?.width || fromContent?.height) {
               dims = { width: fromContent.width, height: fromContent.height }
             }
@@ -389,7 +393,11 @@ export async function fetchRSSFeed(url: string, category: string): Promise<Artic
             id: `${category.replace(/\s+/g, '-').toLowerCase()}-${titleHash}-${sourceHash}-${index}`,
             title: item.title?.trim() || 'Untitled Article',
             description: item.contentSnippet?.trim() || item.summary?.trim() || '',
-            content: item.content?.trim() || item.contentSnippet?.trim() || '',
+            content:
+              ((item as any)['content:encoded'] as string | undefined)?.trim() ||
+              item.content?.trim() ||
+              item.contentSnippet?.trim() ||
+              '',
             url: item.link?.trim() || '',
             urlToImage: imageUrl,
             imageWidth: dims.width,

--- a/src/lib/topics/index.ts
+++ b/src/lib/topics/index.ts
@@ -12,7 +12,6 @@ export const TOPIC_KEYWORDS: Record<string, string[]> = {
     'blockchain',
     'defi',
     'stablecoin',
-    'token',
     'web3',
     'nft',
     'solana',


### PR DESCRIPTION
- Updated fetchRSSFeed to prefer 'content:encoded' when available for improved content extraction.
- Cleaned up content assignment logic to ensure proper trimming and fallback options.
- Removed 'token' from TOPIC_KEYWORDS to streamline topic categorization.