### PR TITLE
feat: make cache TTL configurable via environment variable

### DIFF
--- a/.github/workflows/refresh-homepage.yml
+++ b/.github/workflows/refresh-homepage.yml
@@ -35,3 +35,4 @@ jobs:
           UPSTASH_REDIS_REST_TOKEN: ${{ secrets.KV_REST_API_TOKEN }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           FEED_LOG_LEVEL: ${{ secrets.FEED_LOG_LEVEL }}
+          CACHE_TTL_SECONDS: 43200

--- a/src/lib/homepage/backgroundRefresh.ts
+++ b/src/lib/homepage/backgroundRefresh.ts
@@ -1,4 +1,5 @@
 import { getCachedData, setCachedData } from '../cache'
+import { getCacheTtl } from '../utils'
 import {
   generateFreshHomepage,
   generateTopStorySummaries,
@@ -75,8 +76,7 @@ export async function refreshCacheInBackground(): Promise<void> {
     }
 
     // Update the cached homepage result with enriched data
-    // Cache TTL from environment (default 12 hours)
-    const cacheTtl = Number(process.env.CACHE_TTL_SECONDS) || 43200
+    const cacheTtl = getCacheTtl()
     await setCachedData('homepage-result', finalHomepageResult, cacheTtl)
     await setCachedData('last-cache-update', new Date().toISOString(), cacheTtl)
 

--- a/src/lib/homepage/backgroundRefresh.ts
+++ b/src/lib/homepage/backgroundRefresh.ts
@@ -15,9 +15,7 @@ interface RefreshProgress {
 
 export async function refreshCacheInBackground(): Promise<void> {
   // Skip background refresh in local development unless explicitly enabled
-  const ALLOW_LOCAL = /^(1|true|yes)$/i.test(
-    process.env.ALLOW_LOCAL_BACKGROUND_REFRESH || ''
-  )
+  const ALLOW_LOCAL = /^(1|true|yes)$/i.test(process.env.ALLOW_LOCAL_BACKGROUND_REFRESH || '')
   if (process.env.NODE_ENV === 'development' && !ALLOW_LOCAL) {
     console.log(
       '⏭️ Skipping background refresh in development (set ALLOW_LOCAL_BACKGROUND_REFRESH=1 to enable)'
@@ -77,8 +75,10 @@ export async function refreshCacheInBackground(): Promise<void> {
     }
 
     // Update the cached homepage result with enriched data
-    await setCachedData('homepage-result', finalHomepageResult, 86400) // 24 hours
-    await setCachedData('last-cache-update', new Date().toISOString(), 86400)
+    // Cache TTL from environment (default 12 hours)
+    const cacheTtl = Number(process.env.CACHE_TTL_SECONDS) || 43200
+    await setCachedData('homepage-result', finalHomepageResult, cacheTtl)
+    await setCachedData('last-cache-update', new Date().toISOString(), cacheTtl)
 
     // Mark refresh as complete with short TTL (3 minutes for client to see completion)
     await setCachedData(

--- a/src/lib/homepage/homepageGenerator.ts
+++ b/src/lib/homepage/homepageGenerator.ts
@@ -48,7 +48,7 @@ export async function generateFreshHomepage(): Promise<HomepageData> {
     }
 
     // Cache TTL from environment (default 12 hours)
-    const cacheTtl = Number(process.env.CACHE_TTL_SECONDS) || 43200
+    const cacheTtl = Number(process.env.CACHE_TTL_SECONDS) ?? 43200
     await setCachedData('homepage-result', homepageData, cacheTtl)
     console.log('💾 Cached fresh homepage data')
 

--- a/src/lib/homepage/homepageGenerator.ts
+++ b/src/lib/homepage/homepageGenerator.ts
@@ -47,8 +47,9 @@ export async function generateFreshHomepage(): Promise<HomepageData> {
       lastUpdated: new Date().toISOString(),
     }
 
-    // Cache for 24 hours
-    await setCachedData('homepage-result', homepageData, 86400)
+    // Cache TTL from environment (default 12 hours)
+    const cacheTtl = Number(process.env.CACHE_TTL_SECONDS) || 43200
+    await setCachedData('homepage-result', homepageData, cacheTtl)
     console.log('💾 Cached fresh homepage data')
 
     return homepageData
@@ -148,8 +149,9 @@ async function generateAndCacheSummary(
       throw new Error('Invalid content type for summary generation')
     }
 
-    // Cache for 24 hours to match the refresh cycle
-    await setCachedData(cacheKey, summary, 86400)
+    // Cache TTL from environment (default 12 hours)
+    const cacheTtl = Number(process.env.CACHE_TTL_SECONDS) || 43200
+    await setCachedData(cacheKey, summary, cacheTtl)
     console.log(`✅ Generated and cached summary for ${articleId}`)
   } catch (error) {
     console.error(`❌ Failed to generate summary for ${articleId}:`, error)
@@ -171,7 +173,9 @@ export async function enrichClustersWithSummaries(
         ...cluster,
         // Preserve existing server-generated summary; otherwise, hydrate from cache if available
         summary:
-          cluster.summary || (await getCachedData(getSummaryCacheKey('cluster', clusterId))) || undefined,
+          cluster.summary ||
+          (await getCachedData(getSummaryCacheKey('cluster', clusterId))) ||
+          undefined,
       }
     })
   )

--- a/src/lib/homepage/homepageGenerator.ts
+++ b/src/lib/homepage/homepageGenerator.ts
@@ -5,6 +5,7 @@ import { TOPIC_KEYWORDS } from '../topics'
 import { summarizeArticle, summarizeCluster } from '../ai/groq'
 import { getSummaryCacheKey, SummaryPurpose, getClusterSummaryId } from '../ai/summaryCache'
 import { StoryCluster, Article } from '@/types'
+import { getCacheTtl } from '../utils'
 
 export interface HomepageData {
   storyClusters: StoryCluster[]
@@ -47,8 +48,7 @@ export async function generateFreshHomepage(): Promise<HomepageData> {
       lastUpdated: new Date().toISOString(),
     }
 
-    // Cache TTL from environment (default 12 hours)
-    const cacheTtl = Number(process.env.CACHE_TTL_SECONDS) ?? 43200
+    const cacheTtl = getCacheTtl()
     await setCachedData('homepage-result', homepageData, cacheTtl)
     console.log('💾 Cached fresh homepage data')
 
@@ -149,8 +149,7 @@ async function generateAndCacheSummary(
       throw new Error('Invalid content type for summary generation')
     }
 
-    // Cache TTL from environment (default 12 hours)
-    const cacheTtl = Number(process.env.CACHE_TTL_SECONDS) || 43200
+    const cacheTtl = getCacheTtl()
     await setCachedData(cacheKey, summary, cacheTtl)
     console.log(`✅ Generated and cached summary for ${articleId}`)
   } catch (error) {

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -210,3 +210,11 @@ export function buildCategorySummaryPayload(
     articleCount: orderedArticles.length,
   }
 }
+
+/**
+ * Get the cache TTL from the environment variable
+ * @returns The cache TTL in seconds
+ */
+export const getCacheTtl = (): number => {
+  return Number(process.env.CACHE_TTL_SECONDS) ?? 43200
+}

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -216,5 +216,6 @@ export function buildCategorySummaryPayload(
  * @returns The cache TTL in seconds
  */
 export const getCacheTtl = (): number => {
-  return Number(process.env.CACHE_TTL_SECONDS) ?? 43200
+  const ttl = Number(process.env.CACHE_TTL_SECONDS)
+  return isNaN(ttl) ? 43200 : ttl
 }


### PR DESCRIPTION
- Add CACHE_TTL_SECONDS environment variable for configurable cache duration
- Reduce default TTL from 24 hours to 12 hours to match twice-daily cron schedule
- Apply configurable TTL to homepage data, AI summaries, and cache timestamps
- Update GitHub Actions workflow to set CACHE_TTL_SECONDS=43200
- Maintain backward compatibility with 12-hour default

Benefits:
- Cache never gets stale between cron runs (6 AM & 6 PM UTC)
- Flexible cache duration for different environments
- Easy testing with shorter TTL values
- Better UX with fresher content more frequently