### PR TITLE
refactor: enhance RefreshStatusBar functionality with configurable polling

### DIFF
--- a/src/components/ArticleCard.tsx
+++ b/src/components/ArticleCard.tsx
@@ -43,11 +43,7 @@ export default function ArticleCard({
             variant="compact"
           />
 
-          <ArticleContent
-            article={article}
-            eager={eager}
-            variant="compact"
-          />
+          <ArticleContent article={article} eager={eager} variant="compact" />
 
           <ArticleFooter url={article.url} variant="compact" />
         </CardContent>

--- a/src/components/HomePage/HomeClient.tsx
+++ b/src/components/HomePage/HomeClient.tsx
@@ -104,7 +104,8 @@ export default function HomeClient({ initialData }: HomeClientProps) {
   return (
     <HomeLayout>
       {/* Refresh status bar - shows when background updates are happening */}
-      <RefreshStatusBar />
+      {/* Only show progress bar when user has no data (rare cache miss scenario) */}
+      <RefreshStatusBar showOnlyWhenWaiting={true} hasData={!!data} />
 
       <div className="relative">
         {/* Subtle loading indicator when fetching fresh data - non-blocking */}

--- a/src/components/HomePage/HomeClient.tsx
+++ b/src/components/HomePage/HomeClient.tsx
@@ -104,8 +104,9 @@ export default function HomeClient({ initialData }: HomeClientProps) {
   return (
     <HomeLayout>
       {/* Refresh status bar - shows when background updates are happening */}
-      {/* Only show progress bar when user has no data (rare cache miss scenario) */}
-      <RefreshStatusBar showOnlyWhenWaiting={true} hasData={!!data} />
+      {/* Only shows UI when user has no data (rare cache miss scenario) */}
+      {/* Smart polling runs in background based on cache age */}
+      <RefreshStatusBar hasData={!!data} />
 
       <div className="relative">
         {/* Subtle loading indicator when fetching fresh data - non-blocking */}

--- a/src/components/HomePage/HomeClient.tsx
+++ b/src/components/HomePage/HomeClient.tsx
@@ -10,6 +10,7 @@ import { NewsListSkeleton, HomeHeaderSkeleton, CategorySummarySkeleton } from '@
 import { filterByTopic } from '@/lib/utils'
 import { useHomepageData, HomepageData } from '@/hooks/useHomepageData'
 import { computeTopics } from './utils'
+import { useRefreshIndicator } from '@/hooks/use-refresh-status'
 
 interface HomeClientProps {
   initialData?: HomepageData
@@ -44,6 +45,9 @@ export default function HomeClient({ initialData }: HomeClientProps) {
 
   // Use React Query data if available, fallback to initial data
   const data = homepageData || initialData
+  const refreshIndicator = useRefreshIndicator({
+    enabled: !data,
+  })
 
   // Compute which topics actually have content
   const availableTopics = useMemo(() => computeTopics(data), [data])
@@ -104,9 +108,7 @@ export default function HomeClient({ initialData }: HomeClientProps) {
   return (
     <HomeLayout>
       {/* Refresh status bar - shows when background updates are happening */}
-      {/* Only shows UI when user has no data (rare cache miss scenario) */}
-      {/* Smart polling runs in background based on cache age */}
-      <RefreshStatusBar hasData={!!data} />
+      <RefreshStatusBar showOnlyWhenWaiting hasData={!!data} refreshState={refreshIndicator} />
 
       <div className="relative">
         {/* Subtle loading indicator when fetching fresh data - non-blocking */}

--- a/src/components/RefreshStatusBar.tsx
+++ b/src/components/RefreshStatusBar.tsx
@@ -35,13 +35,14 @@ export default function RefreshStatusBar({
 
   useEffect(() => {
     if (isActive) {
-      // Only show progress bar if:
-      // 1. showOnlyWhenWaiting is false (always show), OR
-      // 2. User has no data yet (they're actually waiting)
       const shouldShow = !showOnlyWhenWaiting || !hasData
 
       if (shouldShow) {
         setIsVisible(true)
+        setShowCompletion(false)
+      } else if (isVisible) {
+        // User now has data but refresh is still active; hide the bar
+        setIsVisible(false)
         setShowCompletion(false)
       }
     } else if (isComplete && isVisible) {
@@ -55,6 +56,10 @@ export default function RefreshStatusBar({
       }, 3000)
 
       return () => clearTimeout(timeout)
+    } else if (!isActive && !isComplete && isVisible) {
+      // Refresh stopped without completion (error/cancel) - hide bar
+      setIsVisible(false)
+      setShowCompletion(false)
     }
   }, [isActive, isComplete, isVisible, showOnlyWhenWaiting, hasData])
 

--- a/src/components/RefreshStatusBar.tsx
+++ b/src/components/RefreshStatusBar.tsx
@@ -61,7 +61,7 @@ export default function RefreshStatusBar({
       setIsVisible(false)
       setShowCompletion(false)
     }
-  }, [isActive, isComplete, isVisible, showOnlyWhenWaiting, hasData])
+  }, [isActive, isComplete, isVisible])
 
   if (!show || !isVisible) return null
 

--- a/src/components/RefreshStatusBar.tsx
+++ b/src/components/RefreshStatusBar.tsx
@@ -4,30 +4,23 @@ import { useRefreshIndicator } from '@/hooks/useRefreshStatus'
 import { useState, useEffect } from 'react'
 
 interface RefreshStatusBarProps {
-  showOnlyWhenWaiting?: boolean // Show only when user is waiting for initial data
   hasData?: boolean // Whether homepage data is available
 }
 
-export default function RefreshStatusBar({
-  showOnlyWhenWaiting = false,
-  hasData = true,
-}: RefreshStatusBarProps) {
-  // Determine if we need aggressive polling
-  // Only poll frequently if user is waiting for data
-  const shouldPollAggressively = showOnlyWhenWaiting ? !hasData : true
-
+export default function RefreshStatusBar({ hasData = true }: RefreshStatusBarProps) {
+  // Always enable polling - smart cache-age-based logic in useRefreshStatus
+  // handles when to actually poll (disabled when cache is fresh)
   const { show, stage, progress, isComplete, isActive } = useRefreshIndicator({
-    enabled: shouldPollAggressively,
+    enabled: true, // Always enabled, but polling is smart based on cache age
   })
   const [isVisible, setIsVisible] = useState(false)
   const [showCompletion, setShowCompletion] = useState(false)
 
   useEffect(() => {
     if (isActive) {
-      // Only show progress if:
-      // 1. showOnlyWhenWaiting is false (always show), OR
-      // 2. User has no data yet (they're actually waiting)
-      const shouldShow = !showOnlyWhenWaiting || !hasData
+      // Only show progress bar if user has no data (waiting for initial load)
+      // This keeps the UI clean when users already have content to read
+      const shouldShow = !hasData
 
       if (shouldShow) {
         setIsVisible(true)
@@ -45,7 +38,7 @@ export default function RefreshStatusBar({
 
       return () => clearTimeout(timeout)
     }
-  }, [isActive, isComplete, isVisible, showOnlyWhenWaiting, hasData])
+  }, [isActive, isComplete, isVisible, hasData])
 
   if (!show || !isVisible) return null
 

--- a/src/hooks/use-refresh-status/__tests__/use-refresh-status.utils.test.ts
+++ b/src/hooks/use-refresh-status/__tests__/use-refresh-status.utils.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { applyJitter, getBackoffInterval, getIdleInterval } from '../utils'
+
+describe('use-refresh-status utils', () => {
+  const originalRandom = Math.random
+
+  beforeEach(() => {
+    // Make jitter deterministic (Math.random() returns 0.5 → no delta)
+    jest.spyOn(Math, 'random').mockReturnValue(0.5)
+  })
+
+  afterEach(() => {
+    ;(Math.random as jest.Mock).mockRestore()
+  })
+
+  describe('applyJitter', () => {
+    it('returns the base interval when Math.random() is 0.5', () => {
+      expect(applyJitter(10_000)).toBe(10_000)
+    })
+
+    it('never goes below 1 second even with negative jitter', () => {
+      ;(Math.random as jest.Mock).mockReturnValue(0) // Max negative jitter
+      expect(applyJitter(500)).toBe(1000)
+    })
+  })
+
+  describe('getBackoffInterval', () => {
+    it('doubles each attempt until hitting the max', () => {
+      expect(getBackoffInterval(1, { baseMs: 5_000, maxMs: 60_000 })).toBe(5_000)
+      expect(getBackoffInterval(2, { baseMs: 5_000, maxMs: 60_000 })).toBe(10_000)
+      expect(getBackoffInterval(3, { baseMs: 5_000, maxMs: 60_000 })).toBe(20_000)
+      expect(getBackoffInterval(5, { baseMs: 5_000, maxMs: 60_000 })).toBe(60_000) // capped
+      expect(getBackoffInterval(10, { baseMs: 5_000, maxMs: 60_000 })).toBe(60_000) // stays capped
+    })
+  })
+
+  describe('getIdleInterval', () => {
+    it('uses slower polling when not enabled (user has data)', () => {
+      // cache age < 60 minutes
+      expect(getIdleInterval(30, { enabled: false })).toBe(30 * 60 * 1000)
+      // cache age between 5 and 5.5 hours
+      expect(getIdleInterval(320, { enabled: false })).toBe(5 * 60 * 1000)
+      // cache age > 6 hours
+      expect(getIdleInterval(400, { enabled: false })).toBe(60 * 1000)
+    })
+
+    it('uses faster polling when enabled (user waiting)', () => {
+      expect(getIdleInterval(30, { enabled: true })).toBe(15 * 60 * 1000)
+      expect(getIdleInterval(320, { enabled: true })).toBe(2 * 60 * 1000)
+      expect(getIdleInterval(400, { enabled: true })).toBe(30 * 1000)
+    })
+  })
+})

--- a/src/hooks/use-refresh-status/__tests__/useRefreshStatus.test.ts
+++ b/src/hooks/use-refresh-status/__tests__/useRefreshStatus.test.ts
@@ -3,24 +3,13 @@
  */
 import { renderHook, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { useRefreshStatus } from '../useRefreshStatus'
+import { useRefreshStatus } from '..'
 import { ReactNode, createElement } from 'react'
 
 // Mock fetch globally
 global.fetch = jest.fn()
 
 const mockFetch = fetch as jest.MockedFunction<typeof fetch>
-
-// Helper to create a QueryClient for tests
-const createTestQueryClient = () =>
-  new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false, // Disable retries for tests
-        gcTime: 0, // Disable cache persistence
-      },
-    },
-  })
 
 describe('useRefreshStatus', () => {
   beforeEach(() => {

--- a/src/hooks/use-refresh-status/utils.ts
+++ b/src/hooks/use-refresh-status/utils.ts
@@ -1,0 +1,37 @@
+const clampInterval = (ms: number) => Math.max(1000, Math.round(ms))
+
+export const applyJitter = (intervalMs: number, variance = 0.1): number => {
+  const delta = intervalMs * variance
+  const jittered = intervalMs + (Math.random() * 2 - 1) * delta
+  return clampInterval(jittered)
+}
+
+export const getBackoffInterval = (
+  attempt: number,
+  { baseMs, maxMs, variance = 0.1 }: { baseMs: number; maxMs: number; variance?: number }
+): number => {
+  const pow = Math.pow(2, Math.max(0, attempt - 1))
+  const interval = Math.min(baseMs * pow, maxMs)
+  return applyJitter(interval || baseMs, variance)
+}
+
+export const getIdleInterval = (
+  cacheAgeMinutes: number,
+  { enabled }: { enabled: boolean }
+): number => {
+  // Enabled = user waiting for data (needs faster updates)
+  if (enabled) {
+    if (cacheAgeMinutes < 60) return applyJitter(15 * 60 * 1000)
+    if (cacheAgeMinutes < 300) return applyJitter(15 * 60 * 1000)
+    if (cacheAgeMinutes < 330) return applyJitter(2 * 60 * 1000)
+    if (cacheAgeMinutes < 360) return applyJitter(60 * 1000)
+    return applyJitter(30 * 1000)
+  }
+
+  // Disabled = user already has data (background detection)
+  if (cacheAgeMinutes < 60) return applyJitter(30 * 60 * 1000)
+  if (cacheAgeMinutes < 300) return applyJitter(30 * 60 * 1000)
+  if (cacheAgeMinutes < 330) return applyJitter(5 * 60 * 1000)
+  if (cacheAgeMinutes < 360) return applyJitter(2 * 60 * 1000)
+  return applyJitter(60 * 1000)
+}

--- a/src/hooks/useRefreshStatus.ts
+++ b/src/hooks/useRefreshStatus.ts
@@ -11,7 +11,12 @@ interface RefreshStatusData {
   justCompleted?: boolean
 }
 
-export function useRefreshStatus() {
+interface UseRefreshStatusOptions {
+  enabled?: boolean // Whether to actively poll for status
+}
+
+export function useRefreshStatus(options: UseRefreshStatusOptions = {}) {
+  const { enabled = true } = options
   const queryClient = useQueryClient()
   const lastCompletedTimestamp = useRef<number | null>(null)
 
@@ -33,6 +38,12 @@ export function useRefreshStatus() {
 
     // Polling configuration based on current status
     refetchInterval: (query) => {
+      // Don't poll if disabled (user has data and doesn't need progress)
+      // They'll get fresh content on next page load
+      if (!enabled) {
+        return false // Completely disable polling
+      }
+
       const data = query.state.data
       if (!data) return 30000 // 30 seconds if no data
 
@@ -119,8 +130,8 @@ export function useRefreshStatus() {
 }
 
 // Helper hook to get just the essential refresh info for UI
-export function useRefreshIndicator() {
-  const { refreshStatus, isRefreshing, justCompleted } = useRefreshStatus()
+export function useRefreshIndicator(options: UseRefreshStatusOptions = {}) {
+  const { refreshStatus, isRefreshing, justCompleted } = useRefreshStatus(options)
 
   return {
     show: isRefreshing || justCompleted,

--- a/src/lib/__tests__/backgroundRefresh.test.ts
+++ b/src/lib/__tests__/backgroundRefresh.test.ts
@@ -101,7 +101,7 @@ describe('backgroundRefresh', () => {
 
       await refreshCacheInBackground()
 
-      // Verify refresh was marked as in progress with 30-minute TTL
+      // Verify refresh was marked as in progress with 10-minute TTL
       expect(mockSetCachedData).toHaveBeenCalledWith(
         'refresh-in-progress',
         expect.objectContaining({
@@ -110,7 +110,7 @@ describe('backgroundRefresh', () => {
           progress: 0,
           timestamp: expect.any(Number),
         }),
-        1800 // 30 minutes (not 1 hour)
+        600 // 10 minutes (not 1 hour)
       )
 
       // Verify all stages were called
@@ -170,9 +170,9 @@ describe('backgroundRefresh', () => {
         (call) => call[0] === 'refresh-in-progress' && call[1].progress < 100
       )
 
-      // Verify all progress updates use consistent 30-minute TTL
+      // Verify all progress updates use consistent 10-minute TTL
       progressCalls.forEach((call) => {
-        expect(call[2]).toBe(1800) // 30 minutes
+        expect(call[2]).toBe(600) // 10 minutes
       })
     })
 
@@ -442,7 +442,7 @@ describe('backgroundRefresh', () => {
       // Verify all TTLs are reasonable (not 1 hour)
       mockSetCachedData.mock.calls.forEach((call) => {
         if (call[0] === 'refresh-in-progress') {
-          expect(call[2]).toBeLessThanOrEqual(1800) // Max 30 minutes
+          expect(call[2]).toBeLessThanOrEqual(600) // Max 10 minutes
         }
       })
     })

--- a/src/lib/cache/index.ts
+++ b/src/lib/cache/index.ts
@@ -11,8 +11,12 @@ try {
     // Will throw if required envs are missing (UPSTASH_REDIS_REST_URL/TOKEN)
     redis = Redis.fromEnv()
   }
-} catch {
+} catch (error) {
   redis = null
+  console.warn(
+    '⚠️ Redis initialization failed. Falling back to in-memory cache only.',
+    (error as Error)?.message ?? error
+  )
 }
 
 const memoryCache = new Map<string, { data: any; expires: number }>()


### PR DESCRIPTION
- Added props to RefreshStatusBar for conditional visibility based on data availability.
- Updated useRefreshStatus and useRefreshIndicator hooks to support polling control.
- Improved logic to show progress only when necessary, enhancing user experience during data loading.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds configurable, smarter refresh-status polling (jitter/backoff) and makes RefreshStatusBar controlled via props, integrates it in HomeClient, and introduces cache key namespacing plus clearing helpers with updated tests/TTLs.
> 
> - **Hooks (refresh-status)**:
>   - Implement smart polling with jitter/backoff and cache-age–aware intervals in `hooks/use-refresh-status/index.ts` using new utils (`applyJitter`, `getIdleInterval`).
>   - Add `enabled` option to `useRefreshStatus` and propagate via `useRefreshIndicator`.
>   - Reset backoff counters on data/mode changes and invalidate `homepage-data` once per completion.
>   - New utilities in `hooks/use-refresh-status/utils.ts` with tests.
> - **UI**:
>   - Convert `RefreshStatusBar` to a controlled component accepting `showOnlyWhenWaiting`, `hasData`, and `refreshState` props; refine visibility/completion handling (`components/RefreshStatusBar.tsx`).
>   - Integrate controlled status bar in `HomePage/HomeClient.tsx` via `useRefreshIndicator({ enabled: !data })`.
> - **Cache**:
>   - Add environment-based cache key prefixing and apply to `getCachedData`/`setCachedData`; add cache clearing helpers (`clearCache`, `clearCacheByPattern`, `clearCacheAll`) in `lib/cache/index.ts`.
>   - Log warning on Redis init failure and fall back to in-memory cache.
> - **Tests**:
>   - Add tests for refresh-status utils and update `useRefreshStatus` tests (single invalidation, error handling).
>   - Adjust background refresh TTL expectations to 10-min progress TTL and 3-min completion/error TTLs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea1dd3cf523f9b58a7a107e284828ccd41aa4919. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->