### PR TITLE
fix: make lazy summary retry trigger explicit refetch

### DIFF
--- a/src/hooks/useLazySummary.ts
+++ b/src/hooks/useLazySummary.ts
@@ -138,6 +138,7 @@ export function useLazySummary({
     data,
     isFetching,
     error: queryError,
+    refetch,
   } = useQuery({
     queryKey: ['summary', variant, effectivePurpose, idForCache, contentPayload.length, length],
     enabled: enabled,
@@ -180,9 +181,8 @@ export function useLazySummary({
 
   const handleRetry = () => {
     setError(null)
-    setHasRequested(false)
-    // Refetch via react-query by invalidating key implicitly through enabled conditions
-    // or rely on retry button to re-trigger by intersection; here we do nothing extra
+    setHasRequested(true)
+    void refetch()
   }
 
   const requestSummary = () => {


### PR DESCRIPTION
## Summary
- make useLazySummary retry explicitly re-enable manual mode requests
- call React Query refetch() from handleRetry so retry does not depend on external effects

## Testing
- pnpm test --runInBand

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to a UI hook’s retry behavior; main risk is altered request timing potentially increasing duplicate refetches if misused.
> 
> **Overview**
> Makes the `useLazySummary` retry flow explicitly re-run the React Query request instead of relying on state/visibility side-effects.
> 
> `handleRetry` now sets `hasRequested` to re-enable manual-mode fetching and calls `refetch()` directly, ensuring the retry button immediately triggers a new `/api/summarize` request when a prior attempt failed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4ce0fac2174844b97e58aaf5d2ac7f9b341a529. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->