### PR TITLE
feat: improve Summary of the Day coverage, prompt, and cache TTL

### DIFF
--- a/src/app/api/summarize/route.ts
+++ b/src/app/api/summarize/route.ts
@@ -45,7 +45,8 @@ export async function POST(request: Request) {
         summary = await summarizeArticle(content)
       }
 
-      // Cache for longer time for clusters since they're more expensive to generate
+      // Category digests are tied to the news data cycle (12h). Clusters cache for 2h,
+      // articles for 1h — both can be regenerated cheaply on demand.
       const cacheTime =
         summaryPurpose === 'category' ? getCacheTtl() : summaryPurpose === 'cluster' ? 7200 : 3600
       await setCachedData(cacheKey, summary, cacheTime)

--- a/src/app/api/summarize/route.ts
+++ b/src/app/api/summarize/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { getCachedData, setCachedData } from '@/lib/cache'
 import { summarizeArticle, summarizeCategoryDigest, summarizeCluster } from '@/lib/ai/groq'
 import { getSummaryCacheKey } from '@/lib/ai/summaryCache'
+import { getCacheTtl } from '@/lib/utils'
 
 export async function POST(request: Request) {
   try {
@@ -46,7 +47,7 @@ export async function POST(request: Request) {
 
       // Cache for longer time for clusters since they're more expensive to generate
       const cacheTime =
-        summaryPurpose === 'cluster' ? 7200 : summaryPurpose === 'category' ? 5400 : 3600
+        summaryPurpose === 'category' ? getCacheTtl() : summaryPurpose === 'cluster' ? 7200 : 3600
       await setCachedData(cacheKey, summary, cacheTime)
 
       console.log(`✅ [AI Generated] ${summaryType} summary cached for: ${articleId}`)

--- a/src/components/Summary/CategorySummary.tsx
+++ b/src/components/Summary/CategorySummary.tsx
@@ -35,7 +35,7 @@ export function CategorySummary({
         clusters,
         [], // No standalone articles - we only summarize clustered stories
         {
-          maxClusters: 4,
+          maxClusters: 7,
           maxArticlesPerCluster: 3,
           maxStandaloneArticles: 0,
         }

--- a/src/lib/ai/groq.ts
+++ b/src/lib/ai/groq.ts
@@ -218,7 +218,7 @@ export async function summarizeCategoryDigest(content: string): Promise<string> 
     ENV_DEFAULTS.summaryFallbackOnLimit
   )
 
-  const prompt = `You are an experienced news editor. Craft a compact two-to-three sentence digest (70-110 words) that captures the main developments spanning these topic highlights. Blend insights across sources, prioritize the newest and most consequential facts, and mention distinct angles when relevant. Avoid marketing language, bullet lists, and source callouts. Here are the notes to synthesize:\n\n${content}`
+  const prompt = `You are an experienced news editor. Write the tightest possible digest that still captures every major development across these topic highlights — typically two to three sentences, never more than four even if there is a lot happening. Compress hard: one strong sentence per story thread, no filler, no source callouts, no bullet lists. Here are the notes to synthesize:\n\n${content}`
 
   try {
     const completion = await groqCall('summarizeCategory', () =>
@@ -232,7 +232,7 @@ export async function summarizeCategoryDigest(content: string): Promise<string> 
         ],
         model: 'llama-3.3-70b-versatile',
         temperature: 0.35,
-        max_tokens: 220,
+        max_tokens: 280,
       })
     )
 


### PR DESCRIPTION
## Summary

- **Broader coverage**: top clusters analyzed increased from 4 → 7, so the digest captures more of the day's major stories
- **Sharper prompt**: removed word floor, capped at 4 sentences max, instructs the LLM to compress hard with one strong sentence per story thread — stays concise on slow days, covers more ground on busy ones
- **Correct cache TTL**: category summaries were expiring at 1.5h independently of the 12h news cycle, causing unnecessary Groq calls; now tied to `getCacheTtl()` so all users share one summary per news cycle

## Test plan

- [ ] Trigger a Summary of the Day — verify it covers 7 story threads instead of 4
- [ ] Confirm the output stays tight (2–4 sentences) even on a busy news day
- [ ] Check Redis/cache logs: second request within 12h should be a cache hit, not a new Groq call
- [ ] Change `CACHE_TTL_SECONDS` env var and verify category summary TTL follows it

🤖 Generated with [Claude Code](https://claude.com/claude-code)