### PR TITLE
feat: enhance NewsList and StoryClusterCard components with related clusters functionality

### DIFF
--- a/src/app/api/summarize/route.ts
+++ b/src/app/api/summarize/route.ts
@@ -45,10 +45,8 @@ export async function POST(request: Request) {
         summary = await summarizeArticle(content)
       }
 
-      // Category digests are tied to the news data cycle (12h). Clusters cache for 2h,
-      // articles for 1h — both can be regenerated cheaply on demand.
-      const cacheTime =
-        summaryPurpose === 'category' ? getCacheTtl() : summaryPurpose === 'cluster' ? 7200 : 3600
+      // All summaries are tied to the news data cycle — no point caching shorter than the refresh interval
+      const cacheTime = getCacheTtl()
       await setCachedData(cacheKey, summary, cacheTime)
 
       console.log(`✅ [AI Generated] ${summaryType} summary cached for: ${articleId}`)

--- a/src/components/NewsList.tsx
+++ b/src/components/NewsList.tsx
@@ -1,11 +1,13 @@
 'use client'
 
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import StoryClusterCard from './StoryClusterCard'
 import { StoryCluster } from '@/types'
 
 // Number of top stories to show prominently
 const TOP_STORIES_COUNT = 4
+// Pixels to leave above the card after scrolling (accounts for sticky header)
+const SCROLL_OFFSET = 88
 
 interface NewsListProps {
   storyClusters: StoryCluster[]
@@ -14,6 +16,42 @@ interface NewsListProps {
 export default function NewsList({ storyClusters }: NewsListProps) {
   const [expandedClusters, setExpandedClusters] = useState<Set<number>>(new Set([0])) // First cluster starts expanded
   const [showMoreStories, setShowMoreStories] = useState(false)
+  const [pendingScrollId, setPendingScrollId] = useState<string | null>(null)
+
+  const clusterMap = useMemo(
+    () => new Map(storyClusters.filter((c) => c.id).map((c) => [c.id!, c])),
+    [storyClusters]
+  )
+
+  // After React commits the DOM (expand + possible More Stories reveal),
+  // scroll to the target card. All three state changes are batched into one
+  // render by React 18, so getBoundingClientRect() always measures the final layout.
+  useEffect(() => {
+    if (!pendingScrollId) return
+    const el = document.getElementById(`cluster-${pendingScrollId}`)
+    if (!el) return
+    const top = el.getBoundingClientRect().top + window.scrollY - SCROLL_OFFSET
+    window.scrollTo({ top, behavior: 'smooth' })
+    setPendingScrollId(null)
+  }, [pendingScrollId, expandedClusters, showMoreStories])
+
+  const handleRelatedClick = useCallback(
+    (id: string) => {
+      const idx = storyClusters.findIndex((c) => c.id === id)
+      if (idx === -1) return
+      // Open "More Stories" section if the target lives there
+      if (idx >= TOP_STORIES_COUNT) setShowMoreStories(true)
+      // Expand the target cluster
+      setExpandedClusters((prev) => {
+        const next = new Set(prev)
+        next.add(idx)
+        return next
+      })
+      // Schedule scroll — fires after the batched render above commits
+      setPendingScrollId(id)
+    },
+    [storyClusters]
+  )
 
   const handleClusterExpansion = useCallback((index: number, isExpanded: boolean) => {
     setExpandedClusters((prev) => {
@@ -30,13 +68,10 @@ export default function NewsList({ storyClusters }: NewsListProps) {
   // Clear "More Stories" expansion state when section is hidden
   const handleToggleMoreStories = () => {
     if (showMoreStories) {
-      // Hiding the section - clear expanded state for more stories indices
       setExpandedClusters((expanded) => {
         const newSet = new Set(expanded)
         for (const idx of expanded) {
-          if (idx >= TOP_STORIES_COUNT) {
-            newSet.delete(idx)
-          }
+          if (idx >= TOP_STORIES_COUNT) newSet.delete(idx)
         }
         return newSet
       })
@@ -72,13 +107,18 @@ export default function NewsList({ storyClusters }: NewsListProps) {
           {topStories.map((cluster, index) => {
             const isExpanded = expandedClusters.has(index)
             const shouldSpanFullWidth = index === 0 || isExpanded
+            const relatedClusters = (cluster.relatedClusterIds || [])
+              .map((id) => clusterMap.get(id))
+              .filter(Boolean) as StoryCluster[]
 
             return (
               <div key={index} className={shouldSpanFullWidth ? 'md:col-span-2' : ''}>
                 <StoryClusterCard
                   cluster={cluster}
+                  relatedClusters={relatedClusters}
                   isFirst={index === 0}
                   onExpansionChange={(expanded) => handleClusterExpansion(index, expanded)}
+                  onRelatedClick={handleRelatedClick}
                 />
               </div>
             )
@@ -95,12 +135,8 @@ export default function NewsList({ storyClusters }: NewsListProps) {
           >
             <div className="flex items-center gap-2">
               <span className="h-6 w-1 rounded-full bg-muted-foreground/30 group-hover:bg-accent transition-colors"></span>
-              <span className="text-lg font-semibold text-foreground">
-                More Stories
-              </span>
-              <span className="text-sm text-muted-foreground">
-                ({moreStories.length})
-              </span>
+              <span className="text-lg font-semibold text-foreground">More Stories</span>
+              <span className="text-sm text-muted-foreground">({moreStories.length})</span>
             </div>
             <svg
               className={`w-5 h-5 text-muted-foreground transition-transform duration-200 ${
@@ -119,13 +155,18 @@ export default function NewsList({ storyClusters }: NewsListProps) {
               {moreStories.map((cluster, index) => {
                 const actualIndex = index + TOP_STORIES_COUNT
                 const isExpanded = expandedClusters.has(actualIndex)
+                const relatedClusters = (cluster.relatedClusterIds || [])
+                  .map((id) => clusterMap.get(id))
+                  .filter(Boolean) as StoryCluster[]
 
                 return (
                   <div key={actualIndex} className={isExpanded ? 'md:col-span-2' : ''}>
                     <StoryClusterCard
                       cluster={cluster}
+                      relatedClusters={relatedClusters}
                       isFirst={false}
                       onExpansionChange={(expanded) => handleClusterExpansion(actualIndex, expanded)}
+                      onRelatedClick={handleRelatedClick}
                     />
                   </div>
                 )

--- a/src/components/StoryClusterCard/index.tsx
+++ b/src/components/StoryClusterCard/index.tsx
@@ -13,14 +13,18 @@ import { ENV_DEFAULTS, envNumber } from '@/lib/config/env'
 
 interface StoryClusterCardProps {
   cluster: StoryCluster
+  relatedClusters?: StoryCluster[]
   isFirst?: boolean // Indicates if this is the first story (above-the-fold)
   onExpansionChange?: (expanded: boolean) => void
+  onRelatedClick?: (id: string) => void
 }
 
 export default function StoryClusterCard({
   cluster,
+  relatedClusters,
   isFirst = false,
   onExpansionChange,
+  onRelatedClick,
 }: StoryClusterCardProps) {
   const articles = cluster.articles || []
   const sourceCount = articles.length
@@ -163,6 +167,28 @@ export default function StoryClusterCard({
           </div>
         </div>
 
+        {/* Related Coverage */}
+        {relatedClusters && relatedClusters.length > 0 && (
+          <div className="mt-4 pt-4 border-t border-border/50">
+            <p className="text-xs text-muted-foreground mb-2">Related Coverage</p>
+            <div className="flex flex-wrap gap-2">
+              {relatedClusters.map((rc, i) => (
+                <button
+                  key={i}
+                  type="button"
+                  onClick={() => rc.id && onRelatedClick?.(rc.id)}
+                  className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-border bg-muted/40 text-xs hover:bg-muted hover:border-accent/50 transition-colors cursor-pointer"
+                >
+                  <span className="truncate max-w-[180px]">{rc.clusterTitle}</span>
+                  <span className="text-muted-foreground shrink-0">
+                    · {rc.articles?.length ?? rc.articleIds.length}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
         {/* Collapsible Sources */}
         <div className="border-t border-border/60 pt-4">
           <button
@@ -213,7 +239,7 @@ export default function StoryClusterCard({
   }
 
   return (
-    <section>
+    <section id={cluster.id ? `cluster-${cluster.id}` : undefined}>
       <Card
         className={
           'relative h-full overflow-hidden border-border/60 shadow-sm transition-all duration-200 hover:border-border hover:shadow-md hover:ring-1 hover:ring-accent/30 ' +

--- a/src/hooks/useLazySummary.ts
+++ b/src/hooks/useLazySummary.ts
@@ -5,6 +5,7 @@ import { useIntersectionObserver } from '@/hooks/useIntersectionObserver'
 import { StoryCluster } from '@/types'
 import { useQuery } from '@tanstack/react-query'
 import { getClusterSummaryId } from '@/lib/ai/summaryCache'
+import { ENV_DEFAULTS } from '@/lib/config/env'
 
 interface UseLazySummaryArgs {
   articleId?: string
@@ -144,8 +145,8 @@ export function useLazySummary({
     enabled: enabled,
     initialData:
       variant === 'cluster' && hasServerSummaryForVariant ? cleanedClusterSummary : undefined,
-    staleTime: variant === 'cluster' ? 7200_000 : 3600_000,
-    gcTime: variant === 'cluster' ? 7200_000 : 3600_000,
+    staleTime: ENV_DEFAULTS.cacheTtlSeconds * 1000,
+    gcTime: ENV_DEFAULTS.cacheTtlSeconds * 1000,
     queryFn: async () => {
       const payload =
         variant === 'cluster'

--- a/src/lib/clustering/clusterService.ts
+++ b/src/lib/clustering/clusterService.ts
@@ -11,7 +11,9 @@ import {
   mergeClustersByEntity,
   expandClusterMembership,
   buildTfIdf,
+  linkRelatedClusters,
 } from './textCluster'
+import { simpleHash } from '@/lib/utils'
 import { ENV_DEFAULTS, envBool, envInt, envNumber } from '@/lib/config/env'
 
 /**
@@ -445,6 +447,17 @@ export async function getStoryClusters(articles: Article[]): Promise<{
     }
     // Sort by score BEFORE doing any server-side summarization
     validClusters = computed.sort((a, b) => (b.score || 0) - (a.score || 0))
+
+    // Assign stable IDs (hash of sorted articleIds)
+    validClusters = validClusters.map((c) => ({
+      ...c,
+      id: `cluster-${simpleHash([...c.articleIds].sort().join('|'))}`,
+    }))
+
+    // Link related clusters (same story, different angle) without merging
+    // Use the original full articleMap (all raw articles), not the diversity-filtered c.articles,
+    // so TF-IDF has full coverage and cross-cluster coherence scores are meaningful.
+    validClusters = linkRelatedClusters(validClusters, articleMap)
 
     // Summarize only top-N clusters to reduce Groq load; others lazy-load on client
     const SUM_TOP = envInt('CLUSTER_SUMMARIZE_TOP_N', ENV_DEFAULTS.clusterSummarizeTopN)

--- a/src/lib/clustering/textCluster.ts
+++ b/src/lib/clustering/textCluster.ts
@@ -159,7 +159,7 @@ export function preClusterArticles(
   }: { threshold?: number; minSize?: number; maxGroup?: number } = {}
 ): StoryCluster[] {
   if (articles.length === 0) return []
-  const { vecs, norms } = buildTfIdf(articles)
+  const { vecs } = buildTfIdf(articles)
 
   // Sort newest first to bias clusters toward current events
   const sorted = [...articles].sort(
@@ -621,6 +621,94 @@ export function expandClusterMembership(
   const toAdd = candidates.slice(0, maxAdd).map((c) => c.id)
   const articleIds = Array.from(new Set([...cluster.articleIds, ...toAdd]))
   return { ...cluster, articleIds }
+}
+
+/**
+ * Link related clusters as sub-angles of the same story without merging them.
+ * Clusters that share entities AND pass a lower coherence threshold are linked:
+ * the larger cluster (by articleIds) gets the smaller cluster's id in relatedClusterIds.
+ */
+export function linkRelatedClusters(
+  clusters: StoryCluster[],
+  articleMap: Map<string, Article>,
+  {
+    minSharedEntities = 2,
+    minEntityLength = 4,
+    minCoherence = 0.03,
+    maxRelatedPerCluster = 5,
+  }: {
+    minSharedEntities?: number
+    minEntityLength?: number
+    minCoherence?: number
+    maxRelatedPerCluster?: number
+  } = {}
+): StoryCluster[] {
+  if (clusters.length <= 1) return clusters
+
+  const allIds = new Set(clusters.flatMap((c) => c.articleIds || []))
+  const allArticles = [...allIds].map((id) => articleMap.get(id)).filter(Boolean) as Article[]
+  const { vecs, norms } = buildTfIdf(allArticles)
+
+  const clusterEntities = clusters.map((c) => {
+    const entities = extractClusterEntities(c, articleMap)
+    return new Set([...entities].filter((e) => e.length >= minEntityLength))
+  })
+
+  // Track candidate related pairs: { parentIdx, childIdx, sim }
+  type Pair = { parentIdx: number; childIdx: number; sim: number }
+  const pairs: Pair[] = []
+
+  for (let i = 0; i < clusters.length; i++) {
+    for (let j = i + 1; j < clusters.length; j++) {
+      let sharedCount = 0
+      for (const entity of clusterEntities[i]) {
+        if (clusterEntities[j].has(entity)) sharedCount++
+      }
+      if (sharedCount < minSharedEntities) continue
+
+      const sim = crossClusterSimilarity(
+        clusters[i].articleIds || [],
+        clusters[j].articleIds || [],
+        vecs,
+        norms
+      )
+      if (sim < minCoherence) continue
+
+      // Larger cluster is parent; smaller is child
+      const iSize = (clusters[i].articleIds || []).length
+      const jSize = (clusters[j].articleIds || []).length
+      if (iSize >= jSize) {
+        pairs.push({ parentIdx: i, childIdx: j, sim })
+      } else {
+        pairs.push({ parentIdx: j, childIdx: i, sim })
+      }
+    }
+  }
+
+  // Group pairs by parent, sort by sim desc, cap at maxRelatedPerCluster
+  const byParent = new Map<number, Pair[]>()
+  for (const p of pairs) {
+    const list = byParent.get(p.parentIdx) || []
+    list.push(p)
+    byParent.set(p.parentIdx, list)
+  }
+
+  const result = clusters.map((c) => ({ ...c }))
+  for (const [parentIdx, pairList] of byParent) {
+    pairList.sort((a, b) => b.sim - a.sim)
+    const childIds = pairList
+      .slice(0, maxRelatedPerCluster)
+      .map((p) => clusters[p.childIdx].id)
+      .filter(Boolean) as string[]
+    if (childIds.length > 0) {
+      result[parentIdx].relatedClusterIds = childIds
+      console.log(
+        `[linkRelatedClusters] "${clusters[parentIdx].clusterTitle}" → related: ${childIds.join(', ')}`
+      )
+    }
+  }
+
+  return result
 }
 
 // Expose private helpers for unit testing only

--- a/src/lib/clustering/textCluster.ts
+++ b/src/lib/clustering/textCluster.ts
@@ -685,25 +685,29 @@ export function linkRelatedClusters(
     }
   }
 
-  // Group pairs by parent, sort by sim desc, cap at maxRelatedPerCluster
-  const byParent = new Map<number, Pair[]>()
+  // Group pairs by each cluster index (bidirectional), sort by sim desc, cap at maxRelatedPerCluster
+  const byCluster = new Map<number, Pair[]>()
   for (const p of pairs) {
-    const list = byParent.get(p.parentIdx) || []
-    list.push(p)
-    byParent.set(p.parentIdx, list)
+    const parentList = byCluster.get(p.parentIdx) || []
+    parentList.push(p)
+    byCluster.set(p.parentIdx, parentList)
+
+    const childList = byCluster.get(p.childIdx) || []
+    childList.push(p)
+    byCluster.set(p.childIdx, childList)
   }
 
   const result = clusters.map((c) => ({ ...c }))
-  for (const [parentIdx, pairList] of byParent) {
+  for (const [idx, pairList] of byCluster) {
     pairList.sort((a, b) => b.sim - a.sim)
-    const childIds = pairList
+    const relatedIds = pairList
       .slice(0, maxRelatedPerCluster)
-      .map((p) => clusters[p.childIdx].id)
+      .map((p) => clusters[p.parentIdx === idx ? p.childIdx : p.parentIdx].id)
       .filter(Boolean) as string[]
-    if (childIds.length > 0) {
-      result[parentIdx].relatedClusterIds = childIds
+    if (relatedIds.length > 0) {
+      result[idx].relatedClusterIds = relatedIds
       console.log(
-        `[linkRelatedClusters] "${clusters[parentIdx].clusterTitle}" → related: ${childIds.join(', ')}`
+        `[linkRelatedClusters] "${clusters[idx].clusterTitle}" → related: ${relatedIds.join(', ')}`
       )
     }
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -32,6 +32,9 @@ export interface StoryCluster {
     label: string
     reasons?: string[]
   }
+  // Stable ID (hash of sorted articleIds) and related cluster links
+  id?: string
+  relatedClusterIds?: string[]
 }
 
 export interface NewsResponse {


### PR DESCRIPTION
- Added logic to link related clusters based on shared entities, improving story coherence.
- Updated NewsList to handle related clusters and trigger scrolling to selected stories.
- Enhanced StoryClusterCard to display related coverage with interactive buttons for user engagement.
- Refactored cache TTL handling in the summarize route to align with the news data cycle.