### PR TITLE
fix: hooks violation in ImageCollage causing crash on cluster expand

### DIFF
--- a/src/components/StoryClusterCard/ImageCollage.tsx
+++ b/src/components/StoryClusterCard/ImageCollage.tsx
@@ -118,13 +118,13 @@ const ImageCollage = ({
 
   // Client-side URL upscaling removed. We rely solely on server-side resolution in clusterService.
 
-  if (urls.length === 0) return null
-
   const autoRowHeight = useMemo(() => {
     if (urls.length <= 1) return 'minmax(clamp(12rem, 30vw, 18rem), 1fr)'
     if (urls.length === 2) return 'minmax(clamp(10rem, 26vw, 16rem), 1fr)'
     return 'minmax(clamp(8.5rem, 22vw, 14rem), 1fr)'
   }, [urls.length])
+
+  if (urls.length === 0) return null
 
   return (
     <div


### PR DESCRIPTION
## Problem
Clicking to expand a cluster caused a crash:
> Rendered fewer hooks than expected. This may be caused by an accidental early return statement.

## Root Cause
`ImageCollage.tsx` had an early return (`if (urls.length === 0) return null`) placed **before** a `useMemo` hook (`autoRowHeight`). When `urls` started empty, the useMemo was skipped. On the next render when images loaded and `urls` became non-empty, React detected a different hook count and threw.

## Fix
Moved the early return to after all hooks, as required by the Rules of Hooks.

## Test plan
- [ ] Expand a cluster with images — no crash
- [ ] Expand a cluster with no images — renders correctly, no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)