### PR TITLE
fix: prevent bulk Groq calls when More Stories section opens

### DIFF
--- a/src/components/StoryClusterCard/index.tsx
+++ b/src/components/StoryClusterCard/index.tsx
@@ -107,7 +107,7 @@ export default function StoryClusterCard({
     variant: 'cluster',
     length: 'short',
     disabled: false,
-    eager: isFirst || !isExpanded,
+    eager: isFirst,
   })
 
   // Early return after all hooks


### PR DESCRIPTION
## Problem
When a user clicked a "Related Coverage" link pointing to a More Stories cluster, `handleRelatedClick` called `setShowMoreStories(true)`, mounting all ~12 More Stories cards at once. Each card had `eager: isFirst || !isExpanded`, so all collapsed cards immediately fired Groq summary requests simultaneously — potentially 12 API calls from a single click.

## Fix
Changed `eager: isFirst || !isExpanded` → `eager: isFirst`

Only the #1 story fetches its summary immediately on mount. All other cards use the intersection observer (`rootMargin: 300px`) to pre-fetch as the user actually scrolls near them — one at a time, not all at once.

## Why pre-fetching is still valuable
Short summaries in collapsed cards are the main signal users use to decide whether to expand a story. The intersection observer ensures summaries are ready by the time a user's eyes reach a card, without the bulk-fetch cost.

## Test plan
- [ ] Click a related cluster link — verify only 1-2 summary requests fire (not 12)
- [ ] Scroll through More Stories — summaries appear as cards come into view
- [ ] Top story (#1) still loads its summary immediately on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)