### PR TITLE
feat: improve related coverage UX with tooltips and scroll highlight

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -184,3 +184,16 @@ body {
     transform: translateX(100%);
   }
 }
+
+/* Highlight pulse for related-coverage scroll target */
+@keyframes highlight-pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(156, 163, 175, 0.5);
+  }
+  30% {
+    box-shadow: 0 0 20px 4px rgba(156, 163, 175, 0.3);
+  }
+  100% {
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+  }
+}

--- a/src/components/NewsList.tsx
+++ b/src/components/NewsList.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import StoryClusterCard from './StoryClusterCard'
 import { StoryCluster } from '@/types'
 
@@ -14,9 +14,10 @@ interface NewsListProps {
 }
 
 export default function NewsList({ storyClusters }: NewsListProps) {
-  const [expandedClusters, setExpandedClusters] = useState<Set<number>>(new Set([0])) // First cluster starts expanded
+  const [expandedClusters, setExpandedClusters] = useState<Set<number>>(new Set([0]))
   const [showMoreStories, setShowMoreStories] = useState(false)
   const [pendingScrollId, setPendingScrollId] = useState<string | null>(null)
+  const [highlightedClusterId, setHighlightedClusterId] = useState<string | null>(null)
 
   const clusterMap = useMemo(
     () => new Map(storyClusters.filter((c) => c.id).map((c) => [c.id!, c])),
@@ -35,23 +36,32 @@ export default function NewsList({ storyClusters }: NewsListProps) {
     setPendingScrollId(null)
   }, [pendingScrollId, expandedClusters, showMoreStories])
 
+  const highlightTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
   const handleRelatedClick = useCallback(
     (id: string) => {
       const idx = storyClusters.findIndex((c) => c.id === id)
       if (idx === -1) return
-      // Open "More Stories" section if the target lives there
       if (idx >= TOP_STORIES_COUNT) setShowMoreStories(true)
-      // Expand the target cluster
       setExpandedClusters((prev) => {
         const next = new Set(prev)
         next.add(idx)
         return next
       })
-      // Schedule scroll — fires after the batched render above commits
       setPendingScrollId(id)
+
+      if (highlightTimerRef.current) clearTimeout(highlightTimerRef.current)
+      setHighlightedClusterId(id)
+      highlightTimerRef.current = setTimeout(() => setHighlightedClusterId(null), 2500)
     },
     [storyClusters]
   )
+
+  useEffect(() => {
+    return () => {
+      if (highlightTimerRef.current) clearTimeout(highlightTimerRef.current)
+    }
+  }, [])
 
   const handleClusterExpansion = useCallback((index: number, isExpanded: boolean) => {
     setExpandedClusters((prev) => {
@@ -117,6 +127,7 @@ export default function NewsList({ storyClusters }: NewsListProps) {
                   cluster={cluster}
                   relatedClusters={relatedClusters}
                   isFirst={index === 0}
+                  isHighlighted={highlightedClusterId === cluster.id}
                   onExpansionChange={(expanded) => handleClusterExpansion(index, expanded)}
                   onRelatedClick={handleRelatedClick}
                 />
@@ -165,6 +176,7 @@ export default function NewsList({ storyClusters }: NewsListProps) {
                       cluster={cluster}
                       relatedClusters={relatedClusters}
                       isFirst={false}
+                      isHighlighted={highlightedClusterId === cluster.id}
                       onExpansionChange={(expanded) => handleClusterExpansion(actualIndex, expanded)}
                       onRelatedClick={handleRelatedClick}
                     />

--- a/src/components/StoryClusterCard/index.tsx
+++ b/src/components/StoryClusterCard/index.tsx
@@ -14,7 +14,8 @@ import { ENV_DEFAULTS, envNumber } from '@/lib/config/env'
 interface StoryClusterCardProps {
   cluster: StoryCluster
   relatedClusters?: StoryCluster[]
-  isFirst?: boolean // Indicates if this is the first story (above-the-fold)
+  isFirst?: boolean
+  isHighlighted?: boolean
   onExpansionChange?: (expanded: boolean) => void
   onRelatedClick?: (id: string) => void
 }
@@ -23,6 +24,7 @@ export default function StoryClusterCard({
   cluster,
   relatedClusters,
   isFirst = false,
+  isHighlighted = false,
   onExpansionChange,
   onRelatedClick,
 }: StoryClusterCardProps) {
@@ -176,10 +178,13 @@ export default function StoryClusterCard({
                 <button
                   key={i}
                   type="button"
+                  title={rc.clusterTitle}
                   onClick={() => rc.id && onRelatedClick?.(rc.id)}
-                  className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-border bg-muted/40 text-xs hover:bg-muted hover:border-accent/50 transition-colors cursor-pointer"
+                  className="group/pill inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border border-border bg-muted/40 text-xs hover:bg-accent/10 hover:border-accent/60 hover:shadow-sm transition-all duration-200 cursor-pointer"
                 >
-                  <span className="truncate max-w-[180px]">{rc.clusterTitle}</span>
+                  <span className="truncate max-w-[240px] group-hover/pill:max-w-[400px] transition-all duration-200">
+                    {rc.clusterTitle}
+                  </span>
                   <span className="text-muted-foreground shrink-0">
                     · {rc.articles?.length ?? rc.articleIds.length}
                   </span>
@@ -243,7 +248,8 @@ export default function StoryClusterCard({
       <Card
         className={
           'relative h-full overflow-hidden border-border/60 shadow-sm transition-all duration-200 hover:border-border hover:shadow-md hover:ring-1 hover:ring-accent/30 ' +
-          (!isExpanded ? 'group cursor-pointer focus-visible:ring-2 focus-visible:ring-ring' : '')
+          (!isExpanded ? 'group cursor-pointer focus-visible:ring-2 focus-visible:ring-ring ' : '') +
+          (isHighlighted ? 'ring-2 ring-accent/70 shadow-lg shadow-accent/10 animate-[highlight-pulse_2s_ease-out]' : '')
         }
         {...cardInteractiveProps}
       >


### PR DESCRIPTION
## Summary
- Add native `title` tooltip on related coverage pills and expand truncation from 180px to 240px (400px on hover) so users can read the full story title
- Highlight the target story card with a ring + pulse glow animation when clicking a related coverage link, auto-clearing after 2.5s
- Improve pill hover styling with accent background, border, and shadow for better discoverability

## Test plan
- [ ] Hover a related coverage pill — verify native tooltip shows full title and pill width expands
- [ ] Click a related coverage pill — verify page scrolls to the target card, which is expanded and highlighted with a glowing ring
- [ ] Confirm the highlight ring fades after ~2.5 seconds
- [ ] Test with a related cluster in the "More Stories" section to verify it auto-opens and scrolls correctly

Made with [Cursor](https://cursor.com)