### PR TITLE
feat: add related story modal with animations and refactor NewsList component

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -184,3 +184,28 @@ body {
     transform: translateX(100%);
   }
 }
+
+/* Related-story modal enter animation */
+dialog[open]::backdrop {
+  animation: fade-in 200ms ease-out;
+}
+
+dialog[open] > div {
+  animation: slide-up 250ms ease-out;
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(16px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}

--- a/src/components/NewsList.tsx
+++ b/src/components/NewsList.tsx
@@ -1,57 +1,37 @@
 'use client'
 
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import StoryClusterCard from './StoryClusterCard'
+import RelatedStoryModal from './StoryClusterCard/RelatedStoryModal'
 import { StoryCluster } from '@/types'
 
-// Number of top stories to show prominently
 const TOP_STORIES_COUNT = 4
-// Pixels to leave above the card after scrolling (accounts for sticky header)
-const SCROLL_OFFSET = 88
 
 interface NewsListProps {
   storyClusters: StoryCluster[]
 }
 
 export default function NewsList({ storyClusters }: NewsListProps) {
-  const [expandedClusters, setExpandedClusters] = useState<Set<number>>(new Set([0])) // First cluster starts expanded
+  const [expandedClusters, setExpandedClusters] = useState<Set<number>>(new Set([0]))
   const [showMoreStories, setShowMoreStories] = useState(false)
-  const [pendingScrollId, setPendingScrollId] = useState<string | null>(null)
+  const [modalClusterId, setModalClusterId] = useState<string | null>(null)
 
   const clusterMap = useMemo(
     () => new Map(storyClusters.filter((c) => c.id).map((c) => [c.id!, c])),
     [storyClusters]
   )
 
-  // After React commits the DOM (expand + possible More Stories reveal),
-  // scroll to the target card. All three state changes are batched into one
-  // render by React 18, so getBoundingClientRect() always measures the final layout.
-  useEffect(() => {
-    if (!pendingScrollId) return
-    const el = document.getElementById(`cluster-${pendingScrollId}`)
-    if (!el) return
-    const top = el.getBoundingClientRect().top + window.scrollY - SCROLL_OFFSET
-    window.scrollTo({ top, behavior: 'smooth' })
-    setPendingScrollId(null)
-  }, [pendingScrollId, expandedClusters, showMoreStories])
+  const modalCluster = modalClusterId ? clusterMap.get(modalClusterId) ?? null : null
+  const modalRelated = useMemo(() => {
+    if (!modalCluster) return []
+    return (modalCluster.relatedClusterIds || [])
+      .map((id) => clusterMap.get(id))
+      .filter(Boolean) as StoryCluster[]
+  }, [modalCluster, clusterMap])
 
-  const handleRelatedClick = useCallback(
-    (id: string) => {
-      const idx = storyClusters.findIndex((c) => c.id === id)
-      if (idx === -1) return
-      // Open "More Stories" section if the target lives there
-      if (idx >= TOP_STORIES_COUNT) setShowMoreStories(true)
-      // Expand the target cluster
-      setExpandedClusters((prev) => {
-        const next = new Set(prev)
-        next.add(idx)
-        return next
-      })
-      // Schedule scroll — fires after the batched render above commits
-      setPendingScrollId(id)
-    },
-    [storyClusters]
-  )
+  const handleRelatedClick = useCallback((id: string) => {
+    setModalClusterId(id)
+  }, [])
 
   const handleClusterExpansion = useCallback((index: number, isExpanded: boolean) => {
     setExpandedClusters((prev) => {
@@ -97,6 +77,13 @@ export default function NewsList({ storyClusters }: NewsListProps) {
 
   return (
     <div className="space-y-10 lg:space-y-12">
+      <RelatedStoryModal
+        cluster={modalCluster}
+        relatedClusters={modalRelated}
+        onClose={() => setModalClusterId(null)}
+        onRelatedClick={handleRelatedClick}
+      />
+
       {/* Top Stories Section */}
       <section>
         <h3 className="mb-4 flex items-center gap-2 text-lg font-semibold text-foreground">

--- a/src/components/StoryClusterCard/ClusterExpandedContent.tsx
+++ b/src/components/StoryClusterCard/ClusterExpandedContent.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { StoryCluster } from '@/types'
+import ImageCollage from './ImageCollage'
+import RelatedCoveragePills from './RelatedCoveragePills'
+import ClusterSummary from '@/components/Summary/ClusterSummary'
+import SourceArticleList from './SourceArticleList'
+
+interface ClusterExpandedContentProps {
+  cluster: StoryCluster
+  relatedClusters?: StoryCluster[]
+  onRelatedClick?: (id: string) => void
+}
+
+export default function ClusterExpandedContent({
+  cluster,
+  relatedClusters,
+  onRelatedClick,
+}: ClusterExpandedContentProps) {
+  const [hasImages, setHasImages] = useState((cluster.imageUrls?.length ?? 0) > 0)
+  useEffect(() => setHasImages((cluster.imageUrls?.length ?? 0) > 0), [cluster.imageUrls])
+  const articles = cluster.articles || []
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <div
+        className={`grid gap-6 ${
+          hasImages
+            ? 'lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] lg:items-stretch'
+            : ''
+        }`}
+      >
+        {hasImages && (
+          <ImageCollage cluster={cluster} onChangeCount={(count) => setHasImages(count > 0)} />
+        )}
+        <div className="flex flex-col gap-6 lg:h-full lg:justify-between">
+          <ClusterSummary cluster={cluster} eager />
+        </div>
+      </div>
+
+      {relatedClusters && relatedClusters.length > 0 && (
+        <RelatedCoveragePills clusters={relatedClusters} onRelatedClick={onRelatedClick} />
+      )}
+
+      <SourceArticleList articles={articles} collapsible showHeader={false} />
+    </div>
+  )
+}

--- a/src/components/StoryClusterCard/RelatedCoveragePills.tsx
+++ b/src/components/StoryClusterCard/RelatedCoveragePills.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { StoryCluster } from '@/types'
+
+interface RelatedCoveragePillsProps {
+  clusters: StoryCluster[]
+  onRelatedClick?: (id: string) => void
+}
+
+export default function RelatedCoveragePills({ clusters, onRelatedClick }: RelatedCoveragePillsProps) {
+  if (!clusters.length) return null
+
+  return (
+    <div className="mt-4 pt-4 border-t border-border/50">
+      <p className="text-xs text-muted-foreground mb-2">Related Coverage</p>
+      <div className="flex flex-wrap gap-2">
+        {clusters.map((rc, i) => (
+          <button
+            key={i}
+            type="button"
+            title={rc.clusterTitle}
+            onClick={() => rc.id && onRelatedClick?.(rc.id)}
+            className="group/pill inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border border-border bg-muted/40 text-xs hover:bg-accent/10 hover:border-accent/60 hover:shadow-sm transition-all duration-200 cursor-pointer"
+          >
+            <span className="truncate max-w-[240px] group-hover/pill:max-w-[400px] transition-all duration-200">
+              {rc.clusterTitle}
+            </span>
+            <span className="text-muted-foreground shrink-0">
+              · {rc.articles?.length ?? rc.articleIds.length}
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/StoryClusterCard/RelatedStoryModal.tsx
+++ b/src/components/StoryClusterCard/RelatedStoryModal.tsx
@@ -1,0 +1,118 @@
+'use client'
+
+import React, { useCallback, useEffect, useMemo, useRef } from 'react'
+import { StoryCluster } from '@/types'
+import { Badge } from '@/components/ui'
+import { formatPublishedLabel } from '@/lib/utils'
+import ClusterExpandedContent from './ClusterExpandedContent'
+
+interface RelatedStoryModalProps {
+  cluster: StoryCluster | null
+  relatedClusters?: StoryCluster[]
+  onClose: () => void
+  onRelatedClick?: (id: string) => void
+}
+
+export default function RelatedStoryModal({
+  cluster,
+  relatedClusters,
+  onClose,
+  onRelatedClick,
+}: RelatedStoryModalProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null)
+  const contentRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (!dialog) return
+
+    if (cluster) {
+      if (!dialog.open) dialog.showModal()
+      contentRef.current?.scrollTo({ top: 0 })
+    } else {
+      if (dialog.open) dialog.close()
+    }
+  }, [cluster])
+
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent<HTMLDialogElement>) => {
+      if (e.target === dialogRef.current) onClose()
+    },
+    [onClose]
+  )
+
+  const handleCancel = useCallback(
+    (e: React.SyntheticEvent<HTMLDialogElement>) => {
+      e.preventDefault()
+      onClose()
+    },
+    [onClose]
+  )
+
+  const publishedLabel = useMemo(
+    () => formatPublishedLabel(cluster?.articles?.[0]?.publishedAt),
+    [cluster?.articles]
+  )
+
+  if (!cluster) return null
+
+  const sourceCount = (cluster.articles || []).length
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onCancel={handleCancel}
+      onClick={handleBackdropClick}
+      className="fixed inset-0 z-50 m-0 h-dvh w-dvw max-h-dvh max-w-none bg-transparent p-0 backdrop:bg-black/60 backdrop:backdrop-blur-sm open:flex open:items-center open:justify-center"
+    >
+      <div
+        ref={contentRef}
+        className="relative mx-auto my-4 flex max-h-[calc(100dvh-2rem)] w-full max-w-3xl flex-col overflow-y-auto rounded-2xl border border-border/60 bg-card text-foreground shadow-2xl sm:my-8 sm:max-h-[calc(100dvh-4rem)]"
+      >
+        {/* Header */}
+        <div className="sticky top-0 z-10 border-b border-border/60 bg-muted/40 backdrop-blur px-6 py-5">
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0 space-y-3">
+              <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                <Badge variant="secondary" className="uppercase tracking-wide">
+                  Related Story
+                </Badge>
+                {cluster.severity?.label && (
+                  <span className="inline-flex items-center rounded-full border border-border/60 px-3 py-1 text-[11px] uppercase tracking-wide text-foreground/70">
+                    {cluster.severity.label}
+                  </span>
+                )}
+              </div>
+              <h2 className="text-2xl font-semibold leading-tight text-foreground sm:text-3xl">
+                {cluster.clusterTitle}
+              </h2>
+              <div className="flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground/80">
+                <span>
+                  Related coverage · {sourceCount} source{sourceCount !== 1 ? 's' : ''}
+                </span>
+                {publishedLabel && <span>Updated {publishedLabel}</span>}
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              className="shrink-0 rounded-lg p-2 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors cursor-pointer"
+              aria-label="Close modal"
+            >
+              <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        {/* Body — shared with StoryClusterCard expanded state */}
+        <ClusterExpandedContent
+          cluster={cluster}
+          relatedClusters={relatedClusters}
+          onRelatedClick={onRelatedClick}
+        />
+      </div>
+    </dialog>
+  )
+}

--- a/src/components/StoryClusterCard/SourceArticleList.tsx
+++ b/src/components/StoryClusterCard/SourceArticleList.tsx
@@ -50,10 +50,17 @@ interface SourceArticleListProps {
   articles: Article[]
   className?: string
   showHeader?: boolean
+  collapsible?: boolean
 }
 
-const SourceArticleList = ({ articles, className, showHeader = true }: SourceArticleListProps) => {
+const SourceArticleList = ({
+  articles,
+  className,
+  showHeader = true,
+  collapsible = false,
+}: SourceArticleListProps) => {
   const [isExpanded, setIsExpanded] = useState(false)
+  const [isRevealed, setIsRevealed] = useState(!collapsible)
   const sourceCount = articles.length
   if (!articles || articles.length === 0) {
     return null
@@ -64,32 +71,62 @@ const SourceArticleList = ({ articles, className, showHeader = true }: SourceArt
 
   return (
     <div className={containerClassName}>
-      {showHeader && (
-        <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-muted-foreground">
-          <span className="inline-flex items-center gap-2 text-sm font-medium text-foreground">
+      {collapsible && (
+        <div className="border-t border-border/60 pt-4">
+          <button
+            type="button"
+            onClick={() => setIsRevealed((v) => !v)}
+            aria-expanded={isRevealed}
+            className="flex items-center gap-2 text-sm font-medium text-foreground hover:text-accent transition-colors cursor-pointer"
+          >
             Coverage from {sourceCount} sources
-            <span className="hidden sm:inline-flex h-1.5 w-1.5 rounded-full bg-accent animate-pulse" />
-          </span>
-          <span className="text-xs uppercase tracking-wide text-muted-foreground/70">Live updates</span>
+            <span className={`transition-transform ${isRevealed ? 'rotate-180' : ''}`} aria-hidden>
+              <svg
+                className="w-4 h-4"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <polyline points="6 9 12 15 18 9" />
+              </svg>
+            </span>
+          </button>
         </div>
       )}
 
-      <div className="space-y-2">
-        {visibleArticles.map((article, index) => (
-          <SourceArticle key={article.id} article={article} index={index} />
-        ))}
-      </div>
+      {isRevealed && (
+        <>
+          {showHeader && !collapsible && (
+            <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-muted-foreground">
+              <span className="inline-flex items-center gap-2 text-sm font-medium text-foreground">
+                Coverage from {sourceCount} sources
+                <span className="hidden sm:inline-flex h-1.5 w-1.5 rounded-full bg-accent animate-pulse" />
+              </span>
+              <span className="text-xs uppercase tracking-wide text-muted-foreground/70">Live updates</span>
+            </div>
+          )}
 
-      {articles.length > 4 && (
-        <div className="pt-2">
-          <Button
-            variant="outline"
-            onClick={() => setIsExpanded(!isExpanded)}
-            className="w-full cursor-pointer"
-          >
-            {isExpanded ? 'Show Less' : `View ${articles.length - 4} More Sources`}
-          </Button>
-        </div>
+          <div className="space-y-2">
+            {visibleArticles.map((article, index) => (
+              <SourceArticle key={article.id} article={article} index={index} />
+            ))}
+          </div>
+
+          {articles.length > 4 && (
+            <div className="pt-2">
+              <Button
+                variant="outline"
+                onClick={() => setIsExpanded(!isExpanded)}
+                className="w-full cursor-pointer"
+              >
+                {isExpanded ? 'Show Less' : `View ${articles.length - 4} More Sources`}
+              </Button>
+            </div>
+          )}
+        </>
       )}
     </div>
   )

--- a/src/components/StoryClusterCard/index.tsx
+++ b/src/components/StoryClusterCard/index.tsx
@@ -2,13 +2,12 @@
 
 import React, { useState, useMemo } from 'react'
 import { StoryCluster } from '@/types'
-import ImageCollage from './ImageCollage'
-import ClusterSummary from '@/components/Summary/ClusterSummary'
-import SourceArticleList from './SourceArticleList'
+import ClusterExpandedContent from './ClusterExpandedContent'
 import { Badge, Card, CardContent, CardHeader, CardTitle } from '@/components/ui'
 import { Button } from '@/components/ui/button'
 import NextImage from 'next/image'
 import { useLazySummary } from '@/hooks/useLazySummary'
+import { formatPublishedLabel } from '@/lib/utils'
 import { ENV_DEFAULTS, envNumber } from '@/lib/config/env'
 
 interface StoryClusterCardProps {
@@ -29,22 +28,12 @@ export default function StoryClusterCard({
   const articles = cluster.articles || []
   const sourceCount = articles.length
   const latestArticle = articles[0]
-  const [hasImages, setHasImages] = useState<boolean>((cluster?.imageUrls?.length || 0) > 0)
   const [isExpanded, setIsExpanded] = useState<boolean>(isFirst)
-  const [showSources, setShowSources] = useState<boolean>(false)
 
-  const publishedLabel = useMemo(() => {
-    try {
-      return new Date(latestArticle.publishedAt).toLocaleDateString('en-US', {
-        month: 'short',
-        day: 'numeric',
-        hour: 'numeric',
-        minute: '2-digit',
-      })
-    } catch {
-      return ''
-    }
-  }, [latestArticle?.publishedAt])
+  const publishedLabel = useMemo(
+    () => formatPublishedLabel(latestArticle?.publishedAt),
+    [latestArticle?.publishedAt]
+  )
 
   const heroImage = useMemo(() => {
     const MIN_W = envNumber('NEXT_PUBLIC_MIN_IMAGE_WIDTH', ENV_DEFAULTS.nextPublicMinImageWidth)
@@ -151,72 +140,11 @@ export default function StoryClusterCard({
 
   const expandedContent = (
     <CardContent className="p-0">
-      <div className="flex flex-col gap-6 p-6">
-        <div
-          className={`grid gap-6 ${
-            hasImages
-              ? 'lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] lg:items-stretch'
-              : ''
-          }`}
-        >
-          {hasImages && (
-            <ImageCollage cluster={cluster} onChangeCount={(count) => setHasImages(count > 0)} />
-          )}
-          <div className="flex flex-col gap-6 lg:h-full lg:justify-between">
-            <ClusterSummary cluster={cluster} eager />
-          </div>
-        </div>
-
-        {/* Related Coverage */}
-        {relatedClusters && relatedClusters.length > 0 && (
-          <div className="mt-4 pt-4 border-t border-border/50">
-            <p className="text-xs text-muted-foreground mb-2">Related Coverage</p>
-            <div className="flex flex-wrap gap-2">
-              {relatedClusters.map((rc, i) => (
-                <button
-                  key={i}
-                  type="button"
-                  onClick={() => rc.id && onRelatedClick?.(rc.id)}
-                  className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-border bg-muted/40 text-xs hover:bg-muted hover:border-accent/50 transition-colors cursor-pointer"
-                >
-                  <span className="truncate max-w-[180px]">{rc.clusterTitle}</span>
-                  <span className="text-muted-foreground shrink-0">
-                    · {rc.articles?.length ?? rc.articleIds.length}
-                  </span>
-                </button>
-              ))}
-            </div>
-          </div>
-        )}
-
-        {/* Collapsible Sources */}
-        <div className="border-t border-border/60 pt-4">
-          <button
-            type="button"
-            onClick={() => setShowSources((v) => !v)}
-            aria-expanded={showSources}
-            className="flex items-center gap-2 text-sm font-medium text-foreground hover:text-accent transition-colors cursor-pointer"
-          >
-            Coverage from {sourceCount} sources
-            <span className={`transition-transform ${showSources ? 'rotate-180' : ''}`} aria-hidden>
-              <svg
-                className="w-4 h-4"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <polyline points="6 9 12 15 18 9" />
-              </svg>
-            </span>
-          </button>
-        </div>
-        {showSources && (
-          <SourceArticleList articles={articles} className="pt-2" showHeader={false} />
-        )}
-      </div>
+      <ClusterExpandedContent
+        cluster={cluster}
+        relatedClusters={relatedClusters}
+        onRelatedClick={onRelatedClick}
+      />
     </CardContent>
   )
 

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -8,6 +8,20 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+export function formatPublishedLabel(dateString: string | undefined): string {
+  if (!dateString) return ''
+  try {
+    return new Date(dateString).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    })
+  } catch {
+    return ''
+  }
+}
+
 /**
  * Simple hash function for generating deterministic IDs from strings
  * Uses bit shifting and character codes to create collision-resistant hashes


### PR DESCRIPTION
- Introduced a new RelatedStoryModal component to display related stories.
- Implemented enter animations for the modal and its backdrop in globals.css.
- Refactored NewsList to manage modal state and related story data.
- Updated StoryClusterCard to use a new ClusterExpandedContent component for better structure.
- Enhanced SourceArticleList with collapsible functionality for improved user experience.