### PR TITLE
[codex] Make homepage refresh mode explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ GROQ_API_KEY=your_groq_api_key_here
 UPSTASH_REDIS_REST_URL=your_upstash_url
 UPSTASH_REDIS_REST_TOKEN=your_upstash_token
 
+# Optional: additional cache namespaces to try on reads before treating a key as a miss.
+# Useful in local development to reuse the production-warmed homepage cache without
+# writing local changes into the production namespace.
+CACHE_READ_FALLBACK_PREFIXES=prod:
+
 # Optional: secure full-cache clear endpoints
 CACHE_CLEAR_TOKEN=your_cache_clear_token
 
@@ -151,6 +156,12 @@ SEVERITY_BOOST_TECH=1              # Boost for tech stories
 # Optional: Performance tuning
 CLUSTER_DIAGNOSTICS=true           # Enable clustering diagnostics
 ```
+
+Homepage generation is controlled by `HOMEPAGE_REFRESH_MODE`:
+
+- `cron-only` (default): `/api/homepage` only serves cached data.
+- `request-refresh`: stale cached data can trigger a background refresh on request.
+- `request-generate`: request traffic may refresh stale cache and generate data on cache miss.
 
 4. **Run the development server**
 

--- a/src/app/api/homepage/__tests__/route.test.ts
+++ b/src/app/api/homepage/__tests__/route.test.ts
@@ -1,0 +1,94 @@
+jest.mock('../../../../lib/cache', () => ({
+  getCachedData: jest.fn(),
+}))
+
+jest.mock('../../../../lib/homepage/backgroundRefresh', () => ({
+  refreshCacheInBackground: jest.fn().mockResolvedValue(undefined),
+}))
+
+import { GET } from '../route'
+import { getCachedData } from '../../../../lib/cache'
+import { refreshCacheInBackground } from '../../../../lib/homepage/backgroundRefresh'
+
+const mockGetCachedData = getCachedData as jest.MockedFunction<typeof getCachedData>
+const mockRefreshCacheInBackground = refreshCacheInBackground as jest.MockedFunction<
+  typeof refreshCacheInBackground
+>
+
+describe('/api/homepage', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    process.env = { ...originalEnv }
+    delete process.env.HOMEPAGE_REFRESH_MODE
+    mockRefreshCacheInBackground.mockResolvedValue()
+    jest.spyOn(console, 'log').mockImplementation(() => {})
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  it('serves cached homepage data without triggering refresh by default', async () => {
+    mockGetCachedData.mockResolvedValueOnce({
+      storyClusters: [],
+      unclusteredArticles: [],
+      rateLimitMessage: null,
+      topics: [],
+      lastUpdated: new Date(Date.now() - 8 * 60 * 60 * 1000).toISOString(),
+    })
+
+    const response = await GET()
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.fromCache).toBe(true)
+    expect(mockRefreshCacheInBackground).not.toHaveBeenCalled()
+  })
+
+  it('triggers refresh for stale cache in request-refresh mode', async () => {
+    process.env.HOMEPAGE_REFRESH_MODE = 'request-refresh'
+    mockGetCachedData.mockResolvedValueOnce({
+      storyClusters: [],
+      unclusteredArticles: [],
+      rateLimitMessage: null,
+      topics: [],
+      lastUpdated: new Date(Date.now() - 8 * 60 * 60 * 1000).toISOString(),
+    })
+
+    const response = await GET()
+
+    expect(response.status).toBe(200)
+    expect(mockRefreshCacheInBackground).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns 503 on cache miss instead of generating homepage data by default', async () => {
+    mockGetCachedData.mockResolvedValueOnce(null).mockResolvedValueOnce(null)
+
+    const response = await GET()
+    const data = await response.json()
+
+    expect(response.status).toBe(503)
+    expect(data.error).toContain('cron-only')
+    expect(mockRefreshCacheInBackground).not.toHaveBeenCalled()
+  })
+
+  it('preserves refresh-in-progress response on cache miss', async () => {
+    mockGetCachedData
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ stage: 'Generating AI summaries...', progress: 50 })
+
+    const response = await GET()
+    const data = await response.json()
+
+    expect(response.status).toBe(503)
+    expect(data.refreshing).toBe(true)
+  })
+})

--- a/src/app/api/homepage/route.ts
+++ b/src/app/api/homepage/route.ts
@@ -2,15 +2,31 @@ import { NextResponse } from 'next/server'
 import { getCachedData } from '@/lib/cache'
 import { refreshCacheInBackground } from '@/lib/homepage/backgroundRefresh'
 import { HomepageData as BaseHomepageData } from '@/lib/homepage/homepageGenerator'
+import { ENV_DEFAULTS, envString } from '@/lib/config/env'
 
 interface HomepageData extends BaseHomepageData {
   fromCache: boolean
   cacheAge?: number
 }
 
+type HomepageRefreshMode = 'cron-only' | 'request-refresh' | 'request-generate'
+
+function getHomepageRefreshMode(): HomepageRefreshMode {
+  const configured = envString('HOMEPAGE_REFRESH_MODE', ENV_DEFAULTS.homepageRefreshMode).trim()
+  if (
+    configured === 'cron-only' ||
+    configured === 'request-refresh' ||
+    configured === 'request-generate'
+  ) {
+    return configured
+  }
+  return 'cron-only'
+}
+
 export async function GET(): Promise<NextResponse<HomepageData | { error: string }>> {
   try {
     console.log('🏠 Homepage API called')
+    const refreshMode = getHomepageRefreshMode()
 
     // Try cached homepage result first (instant response)
     const cachedHomepage = await getCachedData('homepage-result')
@@ -24,8 +40,11 @@ export async function GET(): Promise<NextResponse<HomepageData | { error: string
       const cacheAgeMinutes = Math.floor(cacheAge / (1000 * 60))
       const sixHoursInMs = 6 * 60 * 60 * 1000
 
-      // Check if we should trigger background refresh
-      if (cacheAge > sixHoursInMs) {
+      // Optional escape hatch for environments that still want request-driven refreshes.
+      if (
+        (refreshMode === 'request-refresh' || refreshMode === 'request-generate') &&
+        cacheAge > sixHoursInMs
+      ) {
         console.log(`🔄 Triggering background refresh (cache is ${cacheAgeMinutes} minutes old)`)
         // Don't await - let this run in background
         refreshCacheInBackground().catch((error) => {
@@ -40,7 +59,7 @@ export async function GET(): Promise<NextResponse<HomepageData | { error: string
       })
     }
 
-    // No cache - this should be rare with fixed CACHE_PREFIX
+    // No cache - with cron-owned refreshes this means the cache has not been warmed yet
     console.warn('⚠️ Cache miss detected!')
 
     // Check if a refresh is already in progress
@@ -59,12 +78,21 @@ export async function GET(): Promise<NextResponse<HomepageData | { error: string
       )
     }
 
-    // No refresh in progress and no cache - this is the first request
-    // Allow blocking generation for initial seed (emergency fallback)
+    if (refreshMode !== 'request-generate') {
+      return NextResponse.json(
+        {
+          error:
+            `Homepage cache is not ready yet. Current homepage refresh mode is "${refreshMode}".`,
+        },
+        { status: 503, headers: { 'Retry-After': '60' } }
+      )
+    }
+
+    // Escape hatch for environments that still want a blocking first-generation path.
     console.warn(
       '🚨 No cache and no refresh in progress - generating initial data (this may take 30-60s)'
     )
-    console.warn('📋 This should only happen once. If frequent, check CACHE_PREFIX configuration.')
+    console.warn('📋 This should only happen when HOMEPAGE_REFRESH_MODE=request-generate.')
 
     try {
       const { generateFreshHomepage } = await import('@/lib/homepage/homepageGenerator')

--- a/src/app/api/summarize/__tests__/route.test.ts
+++ b/src/app/api/summarize/__tests__/route.test.ts
@@ -1,0 +1,113 @@
+jest.mock('../../../../lib/cache', () => ({
+  getCachedData: jest.fn(),
+  setCachedData: jest.fn(),
+}))
+
+jest.mock('../../../../lib/ai/groq', () => ({
+  summarizeArticle: jest.fn(),
+  summarizeCategoryDigest: jest.fn(),
+  summarizeCluster: jest.fn(),
+}))
+
+jest.mock('../../../../lib/utils', () => ({
+  getCacheTtl: jest.fn(() => 43200),
+}))
+
+import { POST } from '../route'
+import { getCachedData, setCachedData } from '../../../../lib/cache'
+import {
+  summarizeArticle,
+  summarizeCategoryDigest,
+  summarizeCluster,
+} from '../../../../lib/ai/groq'
+
+const mockGetCachedData = getCachedData as jest.MockedFunction<typeof getCachedData>
+const mockSetCachedData = setCachedData as jest.MockedFunction<typeof setCachedData>
+const mockSummarizeArticle = summarizeArticle as jest.MockedFunction<typeof summarizeArticle>
+const mockSummarizeCategoryDigest = summarizeCategoryDigest as jest.MockedFunction<
+  typeof summarizeCategoryDigest
+>
+const mockSummarizeCluster = summarizeCluster as jest.MockedFunction<typeof summarizeCluster>
+
+describe('/api/summarize', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    mockGetCachedData.mockResolvedValue(null)
+    jest.spyOn(console, 'log').mockImplementation(() => {})
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('does not cache non-cacheable cluster summary placeholders', async () => {
+    mockSummarizeCluster.mockResolvedValue('An error occurred while generating the cluster summary.')
+
+    const request = new Request('http://localhost:3000/api/summarize', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        articleId: 'cluster-1',
+        content: [{ id: 'a1', title: 'Story' }],
+        isCluster: true,
+        clusterTitle: 'Story',
+      }),
+    })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.summary).toBe('An error occurred while generating the cluster summary.')
+    expect(mockSetCachedData).not.toHaveBeenCalled()
+  })
+
+  it('caches valid cluster summaries', async () => {
+    mockSummarizeCluster.mockResolvedValue(
+      'A cohesive multi-source summary with enough detail to be considered valid.'
+    )
+
+    const request = new Request('http://localhost:3000/api/summarize', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        articleId: 'cluster-2',
+        content: [{ id: 'a2', title: 'Story' }],
+        isCluster: true,
+        clusterTitle: 'Story',
+      }),
+    })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.summary).toContain('cohesive multi-source summary')
+    expect(mockSetCachedData).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns cached summaries without regenerating', async () => {
+    mockGetCachedData.mockResolvedValue('Cached summary')
+
+    const request = new Request('http://localhost:3000/api/summarize', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        articleId: 'article-1',
+        content: 'Some article content',
+      }),
+    })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.summary).toBe('Cached summary')
+    expect(mockSummarizeArticle).not.toHaveBeenCalled()
+    expect(mockSummarizeCategoryDigest).not.toHaveBeenCalled()
+    expect(mockSummarizeCluster).not.toHaveBeenCalled()
+    expect(mockSetCachedData).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/api/summarize/route.ts
+++ b/src/app/api/summarize/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { getCachedData, setCachedData } from '@/lib/cache'
 import { summarizeArticle, summarizeCategoryDigest, summarizeCluster } from '@/lib/ai/groq'
-import { getSummaryCacheKey } from '@/lib/ai/summaryCache'
+import { getSummaryCacheKey, shouldPersistSummaryToCache } from '@/lib/ai/summaryCache'
 import { getCacheTtl } from '@/lib/utils'
 
 export async function POST(request: Request) {
@@ -46,10 +46,13 @@ export async function POST(request: Request) {
       }
 
       // All summaries are tied to the news data cycle — no point caching shorter than the refresh interval
-      const cacheTime = getCacheTtl()
-      await setCachedData(cacheKey, summary, cacheTime)
-
-      console.log(`✅ [AI Generated] ${summaryType} summary cached for: ${articleId}`)
+      if (shouldPersistSummaryToCache(summary)) {
+        const cacheTime = getCacheTtl()
+        await setCachedData(cacheKey, summary, cacheTime)
+        console.log(`✅ [AI Generated] ${summaryType} summary cached for: ${articleId}`)
+      } else {
+        console.warn(`⚠️ [AI Generated] Skipping cache for non-cacheable ${summaryType} summary`)
+      }
     } else {
       console.log(`🔄 [Cache Hit] Using cached ${summaryType} summary for: ${articleId}`)
     }

--- a/src/lib/ai/summaryCache.ts
+++ b/src/lib/ai/summaryCache.ts
@@ -2,6 +2,12 @@ import { StoryCluster } from '@/types'
 
 export type SummaryPurpose = 'article' | 'cluster' | 'category'
 
+const NON_CACHEABLE_SUMMARY_VALUES = new Set([
+  'summary not available',
+  'summary could not be generated.',
+  'an error occurred while generating the cluster summary.',
+])
+
 /**
  * Create a consistent cache key for AI summaries regardless of the caller.
  */
@@ -23,4 +29,11 @@ export function getClusterSummaryId(cluster: StoryCluster): string {
     : (cluster.articles || []).map((a) => a.id)
   const key = ids.filter(Boolean).sort().join('-')
   return key ? `cluster-${key}` : `cluster-${(cluster.clusterTitle || 'unknown').trim()}`
+}
+
+export function shouldPersistSummaryToCache(summary: string | null | undefined): summary is string {
+  if (typeof summary !== 'string') return false
+  const normalized = summary.trim().toLowerCase()
+  if (!normalized) return false
+  return !NON_CACHEABLE_SUMMARY_VALUES.has(normalized)
 }

--- a/src/lib/cache/index.ts
+++ b/src/lib/cache/index.ts
@@ -1,7 +1,7 @@
 // Shared cache adapter: prefers Upstash Redis (@upstash/redis) if configured,
 // otherwise uses in-memory Map. This preserves the same API across the app.
 import { Redis } from '@upstash/redis'
-import { ENV_DEFAULTS, envBool } from '@/lib/config/env'
+import { ENV_DEFAULTS, envBool, envString } from '@/lib/config/env'
 
 // Allow forcing Redis off via env for local testing
 const DISABLE_REDIS = envBool('CACHE_DISABLE_REDIS', ENV_DEFAULTS.cacheDisableRedis)
@@ -60,21 +60,36 @@ const getCachePrefix = () => {
 }
 
 // Helper to add prefix to keys
-const prefixKey = (key: string) => `${getCachePrefix()}${key}`
+const prefixKey = (key: string, prefix = getCachePrefix()) => `${prefix}${key}`
+
+const getCacheReadPrefixes = (): string[] => {
+  const primary = getCachePrefix()
+  const fallbacks = envString(
+    'CACHE_READ_FALLBACK_PREFIXES',
+    ENV_DEFAULTS.cacheReadFallbackPrefixes
+  )
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean)
+
+  return Array.from(new Set([primary, ...fallbacks]))
+}
 
 export async function getCachedData(key: string): Promise<any> {
-  const prefixedKey = prefixKey(key)
-
   // Redis first (cross-instance)
   if (redis) {
-    try {
-      const value = await redis.get(prefixedKey)
-      if (value !== null && value !== undefined) return value
-    } catch {}
+    for (const prefix of getCacheReadPrefixes()) {
+      try {
+        const value = await redis.get(prefixKey(key, prefix))
+        if (value !== null && value !== undefined) return value
+      } catch {}
+    }
   }
   // Memory cache fallback (per instance)
-  const cached = memoryCache.get(prefixedKey)
-  if (cached && cached.expires > Date.now()) return cached.data
+  for (const prefix of getCacheReadPrefixes()) {
+    const cached = memoryCache.get(prefixKey(key, prefix))
+    if (cached && cached.expires > Date.now()) return cached.data
+  }
   return null
 }
 

--- a/src/lib/config/env.ts
+++ b/src/lib/config/env.ts
@@ -2,7 +2,9 @@ export const ENV_DEFAULTS = {
   // Cache
   cacheDisableRedis: false,
   cacheTtlSeconds: 43200,
+  cacheReadFallbackPrefixes: '',
   allowLocalBackgroundRefresh: false,
+  homepageRefreshMode: 'cron-only',
 
   // Groq
   groqMaxConcurrency: 2,

--- a/src/lib/homepage/homepageGenerator.ts
+++ b/src/lib/homepage/homepageGenerator.ts
@@ -3,7 +3,12 @@ import { getStoryClusters, getUnclusteredArticles } from '../clustering/clusterS
 import { setCachedData, getCachedData } from '../cache'
 import { TOPIC_KEYWORDS } from '../topics'
 import { summarizeArticle, summarizeCluster } from '../ai/groq'
-import { getSummaryCacheKey, SummaryPurpose, getClusterSummaryId } from '../ai/summaryCache'
+import {
+  getSummaryCacheKey,
+  SummaryPurpose,
+  getClusterSummaryId,
+  shouldPersistSummaryToCache,
+} from '../ai/summaryCache'
 import { StoryCluster, Article } from '@/types'
 import { getCacheTtl } from '../utils'
 
@@ -147,6 +152,11 @@ async function generateAndCacheSummary(
       summary = await summarizeArticle(content)
     } else {
       throw new Error('Invalid content type for summary generation')
+    }
+
+    if (!shouldPersistSummaryToCache(summary)) {
+      console.warn(`⚠️ Skipping cache for non-cacheable summary: ${articleId}`)
+      return
     }
 
     const cacheTtl = getCacheTtl()


### PR DESCRIPTION
## What changed
- replaced the two homepage refresh booleans with a single explicit `HOMEPAGE_REFRESH_MODE`
- made `cron-only` the default so `/api/homepage` serves cached data without triggering refresh or cache-miss generation
- added cache read fallback prefixes so local development can read the production-warmed Redis namespace without writing into it
- documented the new refresh modes and added route coverage for the cron-only and request-refresh behaviors

## Why
Request-driven refresh paths were creating avoidable ambiguity and could add Groq cost outside the twice-daily cron workflow. The old configuration surface also made it harder to tell which behavior was actually active in a given environment.

## Impact
- production can stay on a clear cron-owned refresh policy
- local development can reuse shared cache to avoid unnecessary regeneration cost
- the homepage route behavior is easier to reason about and test

## Root cause
The homepage route mixed cache serving, stale-cache refresh triggering, and optional cache-miss generation behind multiple booleans. That made the runtime policy harder to understand and increased the risk of accidental request-time spend.

## Validation
- `pnpm test -- --runInBand src/app/api/homepage/__tests__/route.test.ts src/lib/__tests__/backgroundRefresh.test.ts`
