### PR TITLE
[codex] Improve summary of the day digest

### DIFF
--- a/src/components/Summary/CategorySummary.tsx
+++ b/src/components/Summary/CategorySummary.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo } from 'react'
 import { StoryCluster } from '@/types'
-import { buildCategorySummaryPayload, simpleHash } from '@/lib/utils'
+import { buildCategorySummaryPayload, parseCategoryDigestSummary, simpleHash } from '@/lib/utils'
 import { useLazySummary } from '@/hooks/useLazySummary'
 import { SummaryBase } from './SummaryBase'
 import { AISummaryTitle, Badge, CategorySummaryContentSkeleton } from '@/components/ui'
@@ -35,8 +35,8 @@ export function CategorySummary({
         clusters,
         [], // No standalone articles - we only summarize clustered stories
         {
-          maxClusters: 7,
-          maxArticlesPerCluster: 3,
+          maxClusters: 4,
+          maxArticlesPerCluster: 2,
           maxStandaloneArticles: 0,
         }
       ),
@@ -70,6 +70,8 @@ export function CategorySummary({
       requestSummary()
     }
   }, [isSummaryOpen, requestSummary, payload])
+
+  const digest = parseCategoryDigestSummary(summary)
 
   // Early returns after all hooks
   if (!payload || !isSummaryOpen) {
@@ -127,7 +129,24 @@ export function CategorySummary({
               </div>
             </div>
             <AISummaryTitle />
-            <p className="text-base leading-relaxed text-foreground/90">{summary}</p>
+            {digest.lede ? (
+              <p className="text-base sm:text-lg leading-relaxed text-foreground font-medium">
+                {digest.lede}
+              </p>
+            ) : null}
+            {digest.takeaways.length > 0 ? (
+              <ul className="space-y-3">
+                {digest.takeaways.map((item, index) => (
+                  <li
+                    key={`${index}-${item}`}
+                    className="flex items-start gap-3 text-sm sm:text-[15px] leading-relaxed text-foreground/85"
+                  >
+                    <span className="mt-2 inline-flex h-1.5 w-1.5 rounded-full bg-foreground/55 shrink-0" />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
             <div className="flex items-center gap-2 text-xs text-muted-foreground">
               <span className="inline-flex h-1.5 w-1.5 rounded-full bg-accent animate-pulse" />
               <span>{articleCountLabel}</span>

--- a/src/lib/__tests__/categoryDigest.test.ts
+++ b/src/lib/__tests__/categoryDigest.test.ts
@@ -1,0 +1,33 @@
+import { parseCategoryDigestSummary } from '../utils'
+
+describe('parseCategoryDigestSummary', () => {
+  it('parses structured JSON digests', () => {
+    const digest = parseCategoryDigestSummary(
+      JSON.stringify({
+        lede: 'Global risk and policy pressure are setting the tone for the day.',
+        takeaways: [
+          'Conflict and central-bank tension are shaping the highest-signal clusters.',
+          'Political and institutional fights remain a major secondary theme.',
+        ],
+      })
+    )
+
+    expect(digest.lede).toBe('Global risk and policy pressure are setting the tone for the day.')
+    expect(digest.takeaways).toEqual([
+      'Conflict and central-bank tension are shaping the highest-signal clusters.',
+      'Political and institutional fights remain a major secondary theme.',
+    ])
+  })
+
+  it('falls back cleanly for legacy plain-text summaries', () => {
+    const digest = parseCategoryDigestSummary(
+      'Risk and policy conflict are defining the day. Markets and geopolitics are driving attention. Domestic political fights remain active.'
+    )
+
+    expect(digest.lede).toBe('Risk and policy conflict are defining the day.')
+    expect(digest.takeaways).toEqual([
+      'Markets and geopolitics are driving attention.',
+      'Domestic political fights remain active.',
+    ])
+  })
+})

--- a/src/lib/ai/groq.ts
+++ b/src/lib/ai/groq.ts
@@ -218,7 +218,24 @@ export async function summarizeCategoryDigest(content: string): Promise<string> 
     ENV_DEFAULTS.summaryFallbackOnLimit
   )
 
-  const prompt = `You are an experienced news editor. Write the tightest possible digest that still captures every major development across these topic highlights — typically two to three sentences, never more than four even if there is a lot happening. Compress hard: one strong sentence per story thread, no filler, no source callouts, no bullet lists. Here are the notes to synthesize:\n\n${content}`
+  const prompt = `You are writing a compact "what matters today" digest for someone who can already see the cluster titles below it.
+Your job is not to recap each cluster. Your job is to answer: what 2-3 forces define the day, and why do they matter?
+
+Return ONLY valid JSON with this shape:
+{"lede": string, "takeaways": string[]}
+
+Rules:
+- Lede: one sentence, 14-22 words.
+- Takeaways: 2-3 items, each one sentence, 10-18 words.
+- Focus on the biggest themes across the top clusters and why the day matters.
+- Add value through synthesis, prioritization, momentum, implications, or what changed.
+- Do NOT restate every cluster title or rewrite the visible headlines.
+- Do NOT mention more than three story threads total.
+- Skip low-signal side stories if they do not shape the day.
+- No source callouts, no markdown, no bullets inside strings, no filler.
+
+Cluster notes:
+${content}`
 
   try {
     const completion = await groqCall('summarizeCategory', () =>
@@ -226,17 +243,20 @@ export async function summarizeCategoryDigest(content: string): Promise<string> 
         messages: [
           {
             role: 'system',
-            content: 'You are a concise but thorough news editor who writes balanced digests.',
+            content:
+              'You are a concise senior news editor. Return valid JSON only. Optimize for synthesis, selectivity, and signal over repetition.',
           },
           { role: 'user', content: prompt },
         ],
         model: 'llama-3.3-70b-versatile',
-        temperature: 0.35,
-        max_tokens: 280,
+        temperature: 0.2,
+        response_format: { type: 'json_object' },
+        max_tokens: 170,
       })
     )
 
-    return completion.choices[0]?.message?.content?.trim() || 'Summary not available'
+    const content = completion.choices[0]?.message?.content?.trim()
+    return content || 'Summary not available'
   } catch (error) {
     if (isRateLimitError(error)) {
       console.warn('⚠️ Rate/Spend limit during category summarization')

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -137,7 +137,7 @@ export function parseCategoryDigestSummary(summary: string | undefined): Categor
       const lede = typeof parsed.lede === 'string' ? parsed.lede.trim() : ''
       const takeaways = Array.isArray(parsed.takeaways)
         ? parsed.takeaways
-            .map((item) => (typeof item === 'string' ? item.trim() : ''))
+            .map((item: unknown) => (typeof item === 'string' ? item.trim() : ''))
             .filter(Boolean)
             .slice(0, 3)
         : []

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -122,6 +122,45 @@ export interface CategorySummaryPayload {
   articleCount: number
 }
 
+export interface CategoryDigest {
+  lede: string
+  takeaways: string[]
+}
+
+export function parseCategoryDigestSummary(summary: string | undefined): CategoryDigest {
+  const normalized = (summary || '').trim()
+  if (!normalized) return { lede: '', takeaways: [] }
+
+  try {
+    const parsed = JSON.parse(normalized)
+    if (parsed && typeof parsed === 'object') {
+      const lede = typeof parsed.lede === 'string' ? parsed.lede.trim() : ''
+      const takeaways = Array.isArray(parsed.takeaways)
+        ? parsed.takeaways
+            .map((item) => (typeof item === 'string' ? item.trim() : ''))
+            .filter(Boolean)
+            .slice(0, 3)
+        : []
+      if (lede || takeaways.length) {
+        return { lede, takeaways }
+      }
+    }
+  } catch {}
+
+  const sentences = normalized
+    .replace(/\s+/g, ' ')
+    .split(/(?<=[.!?])\s+/)
+    .map((part) => part.trim())
+    .filter(Boolean)
+
+  if (sentences.length === 0) return { lede: normalized, takeaways: [] }
+
+  return {
+    lede: sentences[0],
+    takeaways: sentences.slice(1, 3),
+  }
+}
+
 /**
  * Build a normalized payload for category-level summaries using top clusters and headlines.
  */
@@ -166,21 +205,26 @@ export function buildCategorySummaryPayload(
   topClusters.forEach((cluster, index) => {
     const lines: string[] = []
     lines.push(`${index + 1}. ${cluster.clusterTitle}`)
+    lines.push(`Articles: ${(cluster.articles || []).length}`)
+    if (cluster.severity?.label && cluster.severity.label !== 'Other') {
+      lines.push(`Weight: ${cluster.severity.label}`)
+    }
 
     const articles = (cluster.articles || []).slice(0, Math.max(1, maxArticlesPerCluster))
-    articles.forEach((article) => {
-      addArticle(article)
-      const snippet = truncate(
-        sanitize(article.description || article.content || '', 'No description provided.'),
-        220
-      )
-      const source = article.source?.name ? ` (${article.source.name})` : ''
-      lines.push(`- ${article.title}${source}: ${snippet}`)
-    })
+    articles.forEach((article) => addArticle(article))
 
-    if (cluster.summary) {
-      lines.push(`Summary cue: ${truncate(sanitize(cluster.summary), 280)}`)
-    }
+    const cue = cluster.summary
+      ? truncate(sanitize(cluster.summary), 240)
+      : truncate(
+          articles
+            .map((article) => sanitize(article.title))
+            .filter(Boolean)
+            .slice(0, 2)
+            .join(' | '),
+          200
+        )
+
+    if (cue) lines.push(`Cue: ${cue}`)
 
     clusterSections.push(lines.join('\n'))
   })
@@ -205,7 +249,10 @@ export function buildCategorySummaryPayload(
   sections.push(`Topic: ${topicLabel}`)
 
   if (clusterSections.length) {
-    sections.push('Top story groups:\n' + clusterSections.join('\n\n'))
+    sections.push(
+      'Top clusters (use these to infer the dominant day-level themes, not to restate each headline):\n' +
+        clusterSections.join('\n\n')
+    )
   }
 
   if (standaloneLines.length) {


### PR DESCRIPTION
## What changed
- changed the day-level digest prompt to return a short structured JSON shape instead of paragraph prose
- shifted the digest toward synthesis and prioritization so it explains what defines the day rather than repeating visible cluster headlines
- reduced the digest input to fewer top clusters and shorter takeaway targets
- updated the UI to render a compact lede plus a few readable takeaways
- added parser coverage for the new structured digest shape and legacy plain-text fallback

## Why
The previous "Summary of the Day" tended to collapse many unrelated top stories into a dense paragraph, which made it harder to scan and often repeated information the cluster list already showed.

## Impact
- the summary should read as a quick orientation layer over the top clusters
- users can get the shape of the day without reading every cluster
- the digest is shorter, more selective, and easier to parse visually

## Validation
- `pnpm test -- --runInBand src/lib/__tests__/categoryDigest.test.ts src/app/api/summarize/__tests__/route.test.ts`
