### PR TITLE
[codex] reduce summary prewarm cost

### DIFF
--- a/src/lib/homepage/__tests__/homepageGenerator.test.ts
+++ b/src/lib/homepage/__tests__/homepageGenerator.test.ts
@@ -1,0 +1,99 @@
+import { generateTopStorySummaries } from '../homepageGenerator'
+import { getCachedData, setCachedData } from '@/lib/cache'
+import { summarizeArticle, summarizeCluster } from '@/lib/ai/groq'
+import { getSummaryCacheKey, getClusterSummaryId } from '@/lib/ai/summaryCache'
+
+jest.mock('@/lib/cache')
+jest.mock('@/lib/ai/groq')
+
+const mockGetCachedData = getCachedData as jest.MockedFunction<typeof getCachedData>
+const mockSetCachedData = setCachedData as jest.MockedFunction<typeof setCachedData>
+const mockSummarizeArticle = summarizeArticle as jest.MockedFunction<typeof summarizeArticle>
+const mockSummarizeCluster = summarizeCluster as jest.MockedFunction<typeof summarizeCluster>
+
+describe('generateTopStorySummaries', () => {
+  const originalSummaryMode = process.env.NEXT_PUBLIC_SUMMARY_ON_DEMAND
+  const originalCacheTtl = process.env.CACHE_TTL_SECONDS
+
+  const storyClusters = [
+    {
+      clusterTitle: 'Chip export rules tighten',
+      articleIds: ['a1', 'a2'],
+      articles: [
+        { id: 'a1', title: 'A1', url: 'https://example.com/a1' },
+        { id: 'a2', title: 'A2', url: 'https://example.com/a2' },
+      ],
+      summary: 'Existing cluster summary',
+    },
+  ] as any
+
+  const articles = [
+    {
+      id: 'article-1',
+      title: 'Headline',
+      content: 'Body copy',
+      url: 'https://example.com/article-1',
+    },
+  ] as any
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    process.env.CACHE_TTL_SECONDS = '3600'
+    mockGetCachedData.mockResolvedValue(null)
+    mockSetCachedData.mockResolvedValue()
+    mockSummarizeArticle.mockResolvedValue('Article summary')
+    mockSummarizeCluster.mockResolvedValue('Generated cluster summary')
+    jest.spyOn(console, 'log').mockImplementation(() => {})
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    if (originalSummaryMode === undefined) {
+      delete process.env.NEXT_PUBLIC_SUMMARY_ON_DEMAND
+    } else {
+      process.env.NEXT_PUBLIC_SUMMARY_ON_DEMAND = originalSummaryMode
+    }
+
+    if (originalCacheTtl === undefined) {
+      delete process.env.CACHE_TTL_SECONDS
+    } else {
+      process.env.CACHE_TTL_SECONDS = originalCacheTtl
+    }
+  })
+
+  it('reuses an existing cluster summary instead of calling the summarizer again', async () => {
+    process.env.NEXT_PUBLIC_SUMMARY_ON_DEMAND = 'true'
+
+    await generateTopStorySummaries(storyClusters, articles)
+
+    expect(mockSummarizeCluster).not.toHaveBeenCalled()
+    expect(mockSetCachedData).toHaveBeenCalledWith(
+      getSummaryCacheKey('cluster', getClusterSummaryId(storyClusters[0])),
+      'Existing cluster summary',
+      3600
+    )
+  })
+
+  it('skips article summary prewarming when summaries are manual', async () => {
+    process.env.NEXT_PUBLIC_SUMMARY_ON_DEMAND = 'true'
+
+    await generateTopStorySummaries(storyClusters, articles)
+
+    expect(mockSummarizeArticle).not.toHaveBeenCalled()
+  })
+
+  it('continues prewarming article summaries when automatic summaries are enabled', async () => {
+    process.env.NEXT_PUBLIC_SUMMARY_ON_DEMAND = 'false'
+
+    await generateTopStorySummaries(storyClusters, articles)
+
+    expect(mockSummarizeArticle).toHaveBeenCalledWith('Body copy')
+    expect(mockSetCachedData).toHaveBeenCalledWith(
+      getSummaryCacheKey('article', 'article-1'),
+      'Article summary',
+      3600
+    )
+  })
+})

--- a/src/lib/homepage/homepageGenerator.ts
+++ b/src/lib/homepage/homepageGenerator.ts
@@ -11,6 +11,7 @@ import {
 } from '../ai/summaryCache'
 import { StoryCluster, Article } from '@/types'
 import { getCacheTtl } from '../utils'
+import { ENV_DEFAULTS, envBool } from '@/lib/config/env'
 
 export interface HomepageData {
   storyClusters: StoryCluster[]
@@ -76,7 +77,11 @@ export async function generateTopStorySummaries(
   console.log('🤖 Generating AI summaries for top stories...')
 
   const topClusters = storyClusters.slice(0, 10) // Top 10 clusters
-  const topArticles = articles.slice(0, 15) // Top 15 articles
+  const prewarmArticleSummaries = !envBool(
+    'NEXT_PUBLIC_SUMMARY_ON_DEMAND',
+    ENV_DEFAULTS.nextPublicSummaryOnDemand
+  )
+  const topArticles = prewarmArticleSummaries ? articles.slice(0, 15) : []
 
   let completed = 0
   const total = topClusters.length + topArticles.length
@@ -85,7 +90,13 @@ export async function generateTopStorySummaries(
   const clusterPromises = topClusters.map(async (cluster) => {
     try {
       const clusterId = getClusterSummaryId(cluster)
-      await generateAndCacheSummary(clusterId, cluster.articles || [], true, cluster.clusterTitle)
+      await generateAndCacheSummary(
+        clusterId,
+        cluster.articles || [],
+        true,
+        cluster.clusterTitle,
+        cluster.summary
+      )
       completed++
       if (progressCallback) {
         await progressCallback(completed, total)
@@ -130,7 +141,8 @@ async function generateAndCacheSummary(
   articleId: string,
   content: string | Article[],
   isCluster: boolean,
-  clusterTitle?: string
+  clusterTitle?: string,
+  existingSummary?: string
 ): Promise<void> {
   const purpose: SummaryPurpose = isCluster ? 'cluster' : 'article'
   const cacheKey = getSummaryCacheKey(purpose, articleId)
@@ -144,7 +156,9 @@ async function generateAndCacheSummary(
   try {
     let summary: string
 
-    if (isCluster && Array.isArray(content)) {
+    if (isCluster && shouldPersistSummaryToCache(existingSummary)) {
+      summary = existingSummary
+    } else if (isCluster && Array.isArray(content)) {
       // Use the cluster-specific summarizer for multi-sentence cohesive summaries
       summary = await summarizeCluster(content)
     } else if (typeof content === 'string') {


### PR DESCRIPTION
## What changed
- Stop prewarming article summaries during homepage refresh when `NEXT_PUBLIC_SUMMARY_ON_DEMAND=true`
- Reuse an existing cluster summary when one is already present instead of re-summarizing it just to populate the cache
- Add focused tests covering the new warmup policy and cluster-summary reuse

## Why it changed
The homepage refresh path was still generating article summaries in the background even though article summaries are manual in the current UI. That paid for summary calls users did not automatically consume.

## Impact
- Reduces Groq summary calls on each refresh cycle without changing the manual article-summary UX
- Preserves cluster-summary behavior for the homepage
- Keeps the cache contract covered by tests

## Root cause
The prewarm path was not aligned with the current summary mode. It always warmed top article summaries and did not take advantage of cluster summaries already generated earlier in the pipeline.

## Validation
- `pnpm test -- src/lib/homepage/__tests__/homepageGenerator.test.ts src/lib/__tests__/backgroundRefresh.test.ts`
