### PR TITLE
[codex] pause project behind kill switch

### DIFF
--- a/.github/workflows/refresh-homepage.yml
+++ b/.github/workflows/refresh-homepage.yml
@@ -6,8 +6,12 @@ on:
     - cron: '0 18 * * *' # 6 PM UTC - Evening news cycle (US East Coast 2 PM, West Coast 11 AM)
   workflow_dispatch:
 
+env:
+  PROJECT_PAUSED: '1'
+
 jobs:
   refresh:
+    if: ${{ env.PROJECT_PAUSED != '1' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/scripts/run-refresh.ts
+++ b/scripts/run-refresh.ts
@@ -1,7 +1,14 @@
 import 'tsconfig-paths/register'
-import { refreshCacheInBackground } from '@/lib/homepage/backgroundRefresh'
+import { isProjectPaused } from '@/lib/config/projectState'
 
 async function main(): Promise<void> {
+  if (isProjectPaused()) {
+    console.log('Project paused. Homepage refresh CLI exited without running.')
+    return
+  }
+
+  const { refreshCacheInBackground } = await import('@/lib/homepage/backgroundRefresh')
+
   console.log('🚀 Starting homepage cache refresh (CLI)')
   const start = Date.now()
 

--- a/src/app/api/homepage/route.ts
+++ b/src/app/api/homepage/route.ts
@@ -3,6 +3,7 @@ import { getCachedData } from '@/lib/cache'
 import { refreshCacheInBackground } from '@/lib/homepage/backgroundRefresh'
 import { HomepageData as BaseHomepageData } from '@/lib/homepage/homepageGenerator'
 import { ENV_DEFAULTS, envString } from '@/lib/config/env'
+import { isProjectPaused } from '@/lib/config/projectState'
 
 interface HomepageData extends BaseHomepageData {
   fromCache: boolean
@@ -24,29 +25,32 @@ function getHomepageRefreshMode(): HomepageRefreshMode {
 }
 
 export async function GET(): Promise<NextResponse<HomepageData | { error: string }>> {
+  if (isProjectPaused()) {
+    return NextResponse.json(
+      { error: 'Project paused. Live homepage generation has been disabled.' },
+      { status: 410 }
+    )
+  }
+
   try {
     console.log('🏠 Homepage API called')
     const refreshMode = getHomepageRefreshMode()
 
-    // Try cached homepage result first (instant response)
     const cachedHomepage = await getCachedData('homepage-result')
 
     if (cachedHomepage) {
       console.log('⚡ Serving cached homepage data')
 
-      // Calculate cache age
       const lastUpdate = cachedHomepage.lastUpdated
       const cacheAge = lastUpdate ? Date.now() - new Date(lastUpdate).getTime() : Infinity
       const cacheAgeMinutes = Math.floor(cacheAge / (1000 * 60))
       const sixHoursInMs = 6 * 60 * 60 * 1000
 
-      // Optional escape hatch for environments that still want request-driven refreshes.
       if (
         (refreshMode === 'request-refresh' || refreshMode === 'request-generate') &&
         cacheAge > sixHoursInMs
       ) {
         console.log(`🔄 Triggering background refresh (cache is ${cacheAgeMinutes} minutes old)`)
-        // Don't await - let this run in background
         refreshCacheInBackground().catch((error) => {
           console.error('Background refresh failed:', error)
         })
@@ -59,14 +63,11 @@ export async function GET(): Promise<NextResponse<HomepageData | { error: string
       })
     }
 
-    // No cache - with cron-owned refreshes this means the cache has not been warmed yet
     console.warn('⚠️ Cache miss detected!')
 
-    // Check if a refresh is already in progress
     const refreshInProgress = await getCachedData('refresh-in-progress')
 
     if (refreshInProgress) {
-      // Refresh already in progress - return 503 and let client retry
       console.log('⏳ Refresh already in progress, returning 503')
       return NextResponse.json(
         {
@@ -88,7 +89,6 @@ export async function GET(): Promise<NextResponse<HomepageData | { error: string
       )
     }
 
-    // Escape hatch for environments that still want a blocking first-generation path.
     console.warn(
       '🚨 No cache and no refresh in progress - generating initial data (this may take 30-60s)'
     )
@@ -104,7 +104,6 @@ export async function GET(): Promise<NextResponse<HomepageData | { error: string
       })
     } catch (genError) {
       console.error('❌ Failed to generate initial data:', genError)
-      // Trigger background refresh for next time
       refreshCacheInBackground().catch(console.error)
       throw genError
     }

--- a/src/app/api/news/route.ts
+++ b/src/app/api/news/route.ts
@@ -2,8 +2,16 @@ import { NextResponse } from 'next/server'
 import { fetchAllNews } from '@/lib/news/newsService'
 import { getCachedData, setCachedData } from '@/lib/cache'
 import { Article } from '@/types'
+import { isProjectPaused } from '@/lib/config/projectState'
 
 export async function GET(request: Request) {
+  if (isProjectPaused()) {
+    return NextResponse.json(
+      { error: 'Project paused. News ingestion has been disabled.' },
+      { status: 410 }
+    )
+  }
+
   const { searchParams } = new URL(request.url)
   const category = searchParams.get('category')
   const page = parseInt(searchParams.get('page') || '1')
@@ -11,14 +19,12 @@ export async function GET(request: Request) {
 
   const cacheKey = `news=${category || 'all'}-${page}-${limit}`
 
-  // Try cache first
   let articles: Article[] = await getCachedData(cacheKey)
   if (!articles) {
     articles = await fetchAllNews()
-    await setCachedData(cacheKey, articles, 300) // 5 min cache
+    await setCachedData(cacheKey, articles, 300)
   }
 
-  // Filter and paginate
   const filtered = category ? articles.filter((article) => article.category === category) : articles
 
   const startIndex = (page - 1) * limit

--- a/src/app/api/refresh-status/route.ts
+++ b/src/app/api/refresh-status/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { getRefreshStatus } from '@/lib/homepage/backgroundRefresh'
+import { isProjectPaused } from '@/lib/config/projectState'
 
 interface RefreshStatusResponse {
   status: 'idle' | 'refreshing' | 'error'
@@ -12,6 +13,18 @@ interface RefreshStatusResponse {
 }
 
 export async function GET(): Promise<NextResponse<RefreshStatusResponse>> {
+  if (isProjectPaused()) {
+    return NextResponse.json({
+      status: 'idle',
+      stage: 'Project paused',
+      progress: 100,
+      lastUpdate: null,
+      timestamp: Date.now(),
+      cacheAge: undefined,
+      justCompleted: false,
+    })
+  }
+
   try {
     const refreshData = await getRefreshStatus()
 
@@ -25,7 +38,6 @@ export async function GET(): Promise<NextResponse<RefreshStatusResponse>> {
       })
     }
 
-    // Determine status based on the stage
     let status: 'idle' | 'refreshing' | 'error' = 'idle'
     let justCompleted = false
 
@@ -40,10 +52,9 @@ export async function GET(): Promise<NextResponse<RefreshStatusResponse>> {
       status = 'refreshing'
     }
 
-    // Calculate cache age if we have a start time
     let cacheAge: number | undefined
     if (refreshData.startTime && status === 'idle') {
-      cacheAge = Math.floor((Date.now() - refreshData.startTime) / (1000 * 60)) // minutes
+      cacheAge = Math.floor((Date.now() - refreshData.startTime) / (1000 * 60))
     }
 
     const response: RefreshStatusResponse = {

--- a/src/app/api/summarize/route.ts
+++ b/src/app/api/summarize/route.ts
@@ -3,8 +3,16 @@ import { getCachedData, setCachedData } from '@/lib/cache'
 import { summarizeArticle, summarizeCategoryDigest, summarizeCluster } from '@/lib/ai/groq'
 import { getSummaryCacheKey, shouldPersistSummaryToCache } from '@/lib/ai/summaryCache'
 import { getCacheTtl } from '@/lib/utils'
+import { isProjectPaused } from '@/lib/config/projectState'
 
 export async function POST(request: Request) {
+  if (isProjectPaused()) {
+    return NextResponse.json(
+      { error: 'Project paused. AI summarization has been disabled.' },
+      { status: 410 }
+    )
+  }
+
   try {
     const { articleId, content, isCluster, clusterTitle, purpose, length } = await request.json()
 
@@ -24,13 +32,11 @@ export async function POST(request: Request) {
     )
     const summaryType = summaryPurpose
 
-    // Log AI resource usage for optimization tracking
     console.log(`🤖 [AI Summary Request] Type: ${summaryType}, ID: ${articleId}`)
     if (isCluster) {
       console.log(`📊 [Cluster Summary] Title: ${clusterTitle}`)
     }
 
-    // Check cache first
     let summary = await getCachedData(cacheKey)
 
     if (!summary) {
@@ -41,11 +47,9 @@ export async function POST(request: Request) {
       } else if (summaryPurpose === 'category') {
         summary = await summarizeCategoryDigest(content)
       } else {
-        // Regular article summary
         summary = await summarizeArticle(content)
       }
 
-      // All summaries are tied to the news data cycle — no point caching shorter than the refresh interval
       if (shouldPersistSummaryToCache(summary)) {
         const cacheTime = getCacheTtl()
         await setCachedData(cacheKey, summary, cacheTime)

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
+import { Analytics } from '@vercel/analytics/next'
 import './globals.css'
 import QueryProvider from '@/components/QueryProvider'
 import { TooltipProvider } from '@/components/ui/tooltip'
-import { Analytics } from '@vercel/analytics/next'
+import { isProjectPaused } from '@/lib/config/projectState'
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -25,6 +26,8 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
+  const paused = isProjectPaused()
+
   return (
     <html lang="en" className="dark">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
@@ -33,8 +36,8 @@ export default function RootLayout({
             {children}
           </TooltipProvider>
         </QueryProvider>
-        <Analytics />
       </body>
+      {!paused && <Analytics />}
     </html>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,21 +4,45 @@ import { HomepageData } from '@/hooks/useHomepageData'
 import { NewsListSkeleton } from '@/components/ui/Skeleton'
 import HomeLayout from '@/components/HomePage/HomeLayout'
 import { Suspense } from 'react'
+import { isProjectPaused } from '@/lib/config/projectState'
 
-export const revalidate = 0 // Disable static generation, always run server-side
+export const revalidate = 0
 
 export default async function Home({
   searchParams,
 }: {
   searchParams?: Promise<{ [key: string]: string | string[] | undefined }>
 }) {
+  void searchParams
+
+  if (isProjectPaused()) {
+    return (
+      <main className="min-h-screen bg-stone-950 text-stone-100">
+        <div className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center px-6 py-20">
+          <p className="mb-4 text-sm uppercase tracking-[0.3em] text-stone-400">Project Paused</p>
+          <h1 className="text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+            AI News Aggregator is offline.
+          </h1>
+          <p className="mt-6 max-w-2xl text-base leading-7 text-stone-300 sm:text-lg">
+            The live refresh pipeline, AI summaries, and production traffic paths have been
+            disabled to stop ongoing infrastructure and model spend.
+          </p>
+          <div className="mt-10 rounded-2xl border border-stone-800 bg-stone-900/70 p-6">
+            <p className="text-sm text-stone-200">
+              If this project comes back later, it should be restarted intentionally with fresh
+              credentials, an explicit budget, and new schedules.
+            </p>
+          </div>
+        </div>
+      </main>
+    )
+  }
+
   console.log('🏠 SSR: Loading homepage with initial data...')
 
-  // Get initial data for SSR (non-blocking, fast)
   let initialData: HomepageData | null = null
 
   try {
-    // Only try to get cached data for SSR - don't generate fresh data here
     const cachedHomepage = await getCachedData('homepage-result')
 
     if (cachedHomepage) {
@@ -35,7 +59,6 @@ export default async function Home({
     }
   } catch (error) {
     console.error('❌ SSR: Failed to get initial data:', error)
-    // Continue without initial data - client will handle the loading
   }
 
   return (
@@ -52,6 +75,13 @@ export default async function Home({
 }
 
 export async function generateMetadata() {
+  if (isProjectPaused()) {
+    return {
+      title: 'AI News Aggregator - Offline',
+      description: 'This project is paused and no longer serving live AI-generated news updates.',
+    }
+  }
+
   return {
     title: 'AI News Aggregator - Latest News with AI Summaries',
     description: 'Get the latest news with AI-powered summaries. Fast, accurate, and up-to-date.',

--- a/src/lib/config/projectState.ts
+++ b/src/lib/config/projectState.ts
@@ -1,0 +1,5 @@
+import { envBool } from './env'
+
+export function isProjectPaused(): boolean {
+  return envBool('PROJECT_PAUSED', true)
+}

--- a/src/lib/homepage/backgroundRefresh.ts
+++ b/src/lib/homepage/backgroundRefresh.ts
@@ -6,6 +6,7 @@ import {
   enrichClustersWithSummaries,
 } from './homepageGenerator'
 import { ENV_DEFAULTS, envBool } from '@/lib/config/env'
+import { isProjectPaused } from '@/lib/config/projectState'
 
 interface RefreshProgress {
   stage: string
@@ -16,6 +17,11 @@ interface RefreshProgress {
 }
 
 export async function refreshCacheInBackground(): Promise<void> {
+  if (isProjectPaused()) {
+    console.log('⏸️ Background refresh skipped because the project is paused')
+    return
+  }
+
   // Skip background refresh in local development unless explicitly enabled
   const ALLOW_LOCAL = envBool(
     'ALLOW_LOCAL_BACKGROUND_REFRESH',


### PR DESCRIPTION
## What changed
This adds a reversible project pause guard instead of removing the refresh and API implementation.

## Why
The project needs to stop refresh work and model/infrastructure spend while keeping the existing code paths intact for a future restart.

## Impact
When `PROJECT_PAUSED` is enabled, the homepage shows the paused state, live API routes return paused responses, background refresh exits early, analytics stay off, and the refresh workflow is skipped. The underlying refresh, news, and summarization logic remains in the codebase behind the guard.

## Validation
- Ran `pnpm run refresh:cron`
- Confirmed it exits immediately with the paused message instead of running refresh work
